### PR TITLE
Changed genre from using album.styles to album.genres. Fixed genre not showing up.

### DIFF
--- a/app/components/AlbumView/index.js
+++ b/app/components/AlbumView/index.js
@@ -62,7 +62,7 @@ class AlbumView extends React.Component {
 
   render() {
     let { album } = this.props;
-    if (_.some(_.map([album.images, album.artists, album.styles], _.isEmpty))) {
+    if (_.some(_.map([album.images, album.artists, album.genres], _.isEmpty))) {
       return this.renderInvalidData();
     }
     let albumImage = this.getAlbumImage(album);
@@ -108,7 +108,7 @@ class AlbumView extends React.Component {
     return (
       <div className={styles.album_genre}>
         <label>Genre:</label>
-        {album.styles && Object.keys(album.styles) > 0 && album.styles[0]}
+        {album.genres[0]}
       </div>
     );
   }


### PR DESCRIPTION
Unless there is specific reason not to, I think it is better to use genres instead of styles for showing the album genre.

The album genre was not showing for me on any album. "if (_.some(_.map([album.images, album.artists, album.genres], _.isEmpty)))" checks if album.genres is empty, so I think using "album.genres[0]" instead of "album.styles && Object.keys(album.styles) > 0 && album.styles[0]" should be fine.