### PR TITLE
Fixed artists without artwork not loading.

### DIFF
--- a/app/components/ArtistView/index.js
+++ b/app/components/ArtistView/index.js
@@ -32,9 +32,7 @@ class ArtistView extends React.Component {
             className={styles.artist_avatar}
             style={{
               background: `url('${
-                artist.images[1]
-                  ? artist.images[1].resource_url
-                  : artPlaceholder
+                _.get(artist, 'images[1].resource_url', artPlaceholder)
               }')`,
               backgroundRepeat: 'noRepeat',
               backgroundPosition: 'center',
@@ -104,7 +102,7 @@ class ArtistView extends React.Component {
       <div
         style={{
           background: `url('${
-            artist.images[0] ? artist.images[0].resource_url : artPlaceholder
+            _.get(artist, 'images[0].resource_url', artPlaceholder)
           }')`,
           backgroundRepeat: 'noRepeat',
           backgroundPosition: 'center',


### PR DESCRIPTION
When selecting an artist with no artwork I get the error "TypeError: Cannot read property '0' of undefined". This fix simply checks to make sure artist.images is defined before trying to access its elements.

I tested using artist "Omoi"