### PR TITLE
Make Seekbar Container More Visible

### DIFF
--- a/app/components/Seekbar/styles.scss
+++ b/app/components/Seekbar/styles.scss
@@ -8,6 +8,8 @@
   background-color: transparent;
 
   flex: 0 0 auto;
+
+  background-color: rgba(248, 248, 242, 0.25);
 }
 
 .seekbar_fill {

--- a/app/components/Seekbar/styles.scss
+++ b/app/components/Seekbar/styles.scss
@@ -5,11 +5,9 @@
 
   cursor: pointer;
 
-  background-color: transparent;
+  background-color: rgba(248, 248, 242, 0.25);
 
   flex: 0 0 auto;
-
-  background-color: rgba(248, 248, 242, 0.25);
 }
 
 .seekbar_fill {


### PR DESCRIPTION
#### Problem
- I am having a lot of trouble putting my cursor on the seekbar when trying to skip through songs.
#### Solution
- I went ahead and changed the `seekbar_container` background color to make it more visible.
- I used the same background color used for the `volume-slider-container`.