### PR TITLE
Added ability to mute volume when clicking on volume icon

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     ],
     "linebreak-style": [
       "error",
-      "windows"
+      "unix"
     ],
     "quotes": [
       "error",

--- a/app/App.js
+++ b/app/App.js
@@ -230,6 +230,8 @@ class App extends React.Component {
       <VolumeControls
         fill={this.props.player.volume}
         updateVolume={this.props.actions.updateVolume}
+        muted={this.props.player.muted}
+        toggleMute={this.props.actions.toggleMute}
         toggleOption={this.props.actions.toggleOption}
         settings={settings}
       />

--- a/app/actions/player.js
+++ b/app/actions/player.js
@@ -6,6 +6,8 @@ export const PAUSE_PLAYBACK = 'PAUSE_PLAYBACK';
 export const UPDATE_PLAYBACK_PROGRESS = 'UPDATE_PLAYBACK_PROGRESS';
 export const UPDATE_SEEK = 'UPDATE_SEEK';
 export const UPDATE_VOLUME = 'UPDATE_VOLUME';
+export const MUTE_ON = 'MUTE_ON';
+export const MUTE_OFF = 'MUTE_OFF';
 export const UPDATE_PLAYBACK_STREAM_LOADING = 'UPDATE_PLAYBACK_STREAM_LOADING';
 
 export function startPlayback() {
@@ -55,6 +57,31 @@ export function updateVolume(volume) {
   return {
     type: UPDATE_VOLUME,
     payload: volume
+  };
+}
+
+export function muteOn(){
+  return {
+    type: MUTE_ON,
+    payload: null
+  };
+}
+
+export function muteOff(){
+  return {
+    type: MUTE_OFF,
+    payload: null
+  };
+}
+
+export function toggleMute(mute) {
+  return dispatch => {
+    if (mute){
+      dispatch(muteOn());
+      dispatch(updateVolume(0));
+    } else {
+      dispatch(muteOff());
+    }
   };
 }
 

--- a/app/actions/player.js
+++ b/app/actions/player.js
@@ -6,8 +6,8 @@ export const PAUSE_PLAYBACK = 'PAUSE_PLAYBACK';
 export const UPDATE_PLAYBACK_PROGRESS = 'UPDATE_PLAYBACK_PROGRESS';
 export const UPDATE_SEEK = 'UPDATE_SEEK';
 export const UPDATE_VOLUME = 'UPDATE_VOLUME';
-export const MUTE_ON = 'MUTE_ON';
-export const MUTE_OFF = 'MUTE_OFF';
+export const MUTE = 'MUTE';
+export const UNMUTE = 'UNMUTE';
 export const UPDATE_PLAYBACK_STREAM_LOADING = 'UPDATE_PLAYBACK_STREAM_LOADING';
 
 export function startPlayback() {
@@ -60,27 +60,26 @@ export function updateVolume(volume) {
   };
 }
 
-export function muteOn(){
+export function mute(){
   return {
-    type: MUTE_ON,
+    type: MUTE,
     payload: null
   };
 }
 
-export function muteOff(){
+export function unMute(){
   return {
-    type: MUTE_OFF,
+    type: UNMUTE,
     payload: null
   };
 }
 
-export function toggleMute(mute) {
+export function toggleMute(muted) {
   return dispatch => {
-    if (mute){
-      dispatch(muteOn());
-      dispatch(updateVolume(0));
+    if (muted){
+      dispatch(mute());
     } else {
-      dispatch(muteOff());
+      dispatch(unMute());
     }
   };
 }

--- a/app/components/VolumeControls/index.js
+++ b/app/components/VolumeControls/index.js
@@ -8,40 +8,12 @@ import VolumeSlider from './VolumeSlider';
 
 class VolumeControls extends React.Component {
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      isVolumeMuted: false,
-      volume: 100
-    };
-  }
-
   handleClick(value) {
-    this.setState({
-      volume: value,
-      isVolumeMuted: this.state.isVolumeMuted && value === 0
-    });
     return this.props.updateVolume(value);
   }
 
-  toggleMute = () => {
-    if (this.state.isVolumeMuted) {
-      this.handleMuteOff();
-    } else {
-      this.handleMuteOn();
-    }
-
-    this.setState({
-      isVolumeMuted: !this.state.isVolumeMuted
-    });
-  }
-
-  handleMuteOn() {
-    this.props.updateVolume(0);
-  }
-
-  handleMuteOff() {
-    this.handleClick(this.state.volume);
+  toggleMute(){
+    this.props.toggleMute(!this.props.muted);
   }
 
   render() {
@@ -52,12 +24,12 @@ class VolumeControls extends React.Component {
           settings={this.props.settings}
         />
         <div className={styles.volume_speaker_control}
-          onClick={this.toggleMute}>
-          <FontAwesome name={this.state.isVolumeMuted ? 'volume-off' : 'volume-up'} />
+          onClick={this.toggleMute.bind(this)}>
+          <FontAwesome name={this.props.muted ? 'volume-off' : 'volume-up'} />
         </div>
 
         <VolumeSlider
-          fill={this.state.volume}
+          fill={this.props.fill}
           handleClick={this.handleClick.bind(this)}
         />
       </div>

--- a/app/components/VolumeControls/index.js
+++ b/app/components/VolumeControls/index.js
@@ -8,10 +8,42 @@ import VolumeSlider from './VolumeSlider';
 
 class VolumeControls extends React.Component {
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      isVolumeMuted: false,
+      volume: 100
+    };
+  }
+
   handleClick(value) {
+    this.setState({
+      volume: value,
+      isVolumeMuted: this.state.isVolumeMuted && value === 0
+    });
     return this.props.updateVolume(value);
   }
-  
+
+  toggleMute = () => {
+    if (this.state.isVolumeMuted) {
+      this.handleMuteOff();
+    } else {
+      this.handleMuteOn();
+    }
+
+    this.setState({
+      isVolumeMuted: !this.state.isVolumeMuted
+    });
+  }
+
+  handleMuteOn() {
+    this.props.updateVolume(0);
+  }
+
+  handleMuteOff() {
+    this.handleClick(this.state.volume);
+  }
+
   render() {
     return (
       <div className={styles.volume_controls_container}>
@@ -19,11 +51,15 @@ class VolumeControls extends React.Component {
           toggleOption={this.props.toggleOption}
           settings={this.props.settings}
         />
-        <FontAwesome name='volume-up'/>
+        <div className={styles.volume_speaker_control}
+          onClick={this.toggleMute}>
+          <FontAwesome name={this.state.isVolumeMuted ? 'volume-off' : 'volume-up'} />
+        </div>
+
         <VolumeSlider
-          fill={this.props.fill}
+          fill={this.state.volume}
           handleClick={this.handleClick.bind(this)}
-	      />
+        />
       </div>
     );
   }

--- a/app/components/VolumeControls/styles.scss
+++ b/app/components/VolumeControls/styles.scss
@@ -15,3 +15,12 @@
 
   font-size: 24px;
 }
+
+.volume_speaker_control{
+    display: flex;
+
+    cursor: pointer;
+
+    width: 50px;
+    height: 52px
+}

--- a/app/containers/SoundContainer/index.js
+++ b/app/containers/SoundContainer/index.js
@@ -150,7 +150,7 @@ class SoundContainer extends React.Component {
         onLoading={this.handleLoading.bind(this)}
         onLoad={this.handleLoaded.bind(this)}
         position={player.seek}
-        volume={player.volume}
+        volume={player.muted ? 0 : player.volume}
       />
     );
   }

--- a/app/reducers/player.js
+++ b/app/reducers/player.js
@@ -6,8 +6,8 @@ import {
   UPDATE_PLAYBACK_PROGRESS,
   UPDATE_SEEK,
   UPDATE_VOLUME,
-  MUTE_ON,
-  MUTE_OFF,
+  MUTE,
+  UNMUTE,
   UPDATE_PLAYBACK_STREAM_LOADING
 } from '../actions/player';
 
@@ -49,11 +49,11 @@ export default function PlayerReducer(state=initialState, action) {
     return Object.assign({}, state, {
       volume: action.payload
     });
-  case MUTE_ON:
+  case MUTE:
     return Object.assign({}, state, {
       muted: true
     });
-  case MUTE_OFF:
+  case UNMUTE:
     return Object.assign({}, state, {
       muted: false
     });

--- a/app/reducers/player.js
+++ b/app/reducers/player.js
@@ -6,6 +6,8 @@ import {
   UPDATE_PLAYBACK_PROGRESS,
   UPDATE_SEEK,
   UPDATE_VOLUME,
+  MUTE_ON,
+  MUTE_OFF,
   UPDATE_PLAYBACK_STREAM_LOADING
 } from '../actions/player';
 
@@ -20,7 +22,8 @@ const initialState = {
   playbackStreamLoading: false,
   playbackProgress: 0,
   seek: 0,
-  volume: 100
+  volume: 100,
+  muted: false
 };
 
 export default function PlayerReducer(state=initialState, action) {
@@ -45,6 +48,14 @@ export default function PlayerReducer(state=initialState, action) {
   case UPDATE_VOLUME:
     return Object.assign({}, state, {
       volume: action.payload
+    });
+  case MUTE_ON:
+    return Object.assign({}, state, {
+      muted: true
+    });
+  case MUTE_OFF:
+    return Object.assign({}, state, {
+      muted: false
     });
   case NEXT_SONG:
   case PREVIOUS_SONG:


### PR DESCRIPTION
Implemented Feature request (https://github.com/nukeop/nuclear/issues/226)

Volume icon changes to fontawesome's `volume-off` icon when clicking on it

> When volume is not muted

<img width="206" alt="volume_speaker_control_on" src="https://user-images.githubusercontent.com/5574015/52053408-59f04800-25ad-11e9-8d39-c9400f454e82.png">

> When volume is muted
<img width="206" alt="volume_speaker_control" src="https://user-images.githubusercontent.com/5574015/52053514-a63b8800-25ad-11e9-95ae-4c355d11560a.png">