### PR TITLE
Remove '&' from last.fm track name

### DIFF
--- a/app/rest/LastFm.js
+++ b/app/rest/LastFm.js
@@ -12,7 +12,7 @@ function makeLastfmRequest (parameters) {
 }
 
 function searchTracks (terms, limit = 30) {
-  let parameters = 'track.search&track=' + encodeURI(terms).replace('&', '');
+  let parameters = 'track.search&track=' + encodeURIComponent(terms);
   parameters += '&limit=' + limit
   return makeLastfmRequest(parameters);
 }

--- a/app/rest/LastFm.js
+++ b/app/rest/LastFm.js
@@ -12,7 +12,7 @@ function makeLastfmRequest (parameters) {
 }
 
 function searchTracks (terms, limit = 30) {
-  let parameters = 'track.search&track=' + encodeURI(terms);
+  let parameters = 'track.search&track=' + encodeURI(terms).replace('&', '');
   parameters += '&limit=' + limit
   return makeLastfmRequest(parameters);
 }


### PR DESCRIPTION
Currently last.fm returns wrong results if the track name contains a '&'-symbol, because it tries to get results from an url like this:

`http://ws.audioscrobbler.com/2.0/?method=track.search&track=Artist1%20&%20Artist2%20Trackname&limit=[...]`
so basically everything after Artist1%20 gets cut off, which leads to wrong results in many cases. This issue happened only after searching for a youtube url.

Example:
Enter this link in the search bar: https://www.youtube.com/watch?v=hj4g-hHw9CI (track name is Deadly Guns & E-Force - Invincible)
The song result is Deadly Guns - Deadly Venoms (Official Snakepit 2017 Anthem) because it searches only for Deadly Guns.
