### PR TITLE
Disable back and forward buttons when no history exists

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -90,6 +90,8 @@ class App extends React.Component {
         <NavButtons
           back={this.props.history.goBack}
           forward={this.props.history.goForward}
+          historyLength={this.props.history.length}
+          historyCurrentIndex={this.props.history.index}
         />
         <SearchBoxContainer />
         <Spacer />

--- a/app/components/NavButtons/index.js
+++ b/app/components/NavButtons/index.js
@@ -1,33 +1,50 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FontAwesome from 'react-fontawesome';
-
+import cx from 'classnames';
 import styles from './styles.scss';
 
-const NavButtons = props => {
+class NavButtons extends React.Component {
 
-  let enableBackButton = true;
-  let enableForwardButton = true;
-
-  if (props.historyCurrentIndex == 1) {
-    enableBackButton = false;
+  constructor(props) {
+    super(props);
+    this.enableBackButton = this.enableBackButton.bind(this);
+    this.enableForwardButton = this.enableForwardButton.bind(this);
   }
 
-  if (props.historyCurrentIndex == (props.historyLength - 1)) {
-    enableForwardButton = false;
+  enableBackButton(currentHistoryIndex) {
+    if (currentHistoryIndex == 1) {
+      return false;
+    } else {
+      return true;
+    }
   }
 
-  return (
-    <div className={styles.nav_buttons}>
-      <a href='#' onClick={(enableBackButton ? props.back : null)} className={(enableBackButton ? null : 'disable' )}>
-        {enableBackButton ? <FontAwesome name='chevron-left'/> : <FontAwesome name='chevron-left'/>}
-      </a>
-      <a href='#' onClick={(enableForwardButton ? props.forward : null)} className={(enableForwardButton ? null : 'disable')}>
-        {enableForwardButton ? <FontAwesome name="chevron-right"/> : <FontAwesome name='chevron-right'/>}
-      </a>
-    </div>
-  );
-};
+  enableForwardButton(currentHistoryIndex, historyLength) {
+    if(currentHistoryIndex == (historyLength - 1)) {
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  render() {
+    let { back, forward, historyLength, historyCurrentIndex} = this.props;
+
+    return (
+      <div className={styles.nav_buttons}>
+        <a href='#' onClick={(this.enableBackButton(historyLength) && back)} 
+          className={cx({'disable': !this.enableBackButton(historyLength)})}>
+            <FontAwesome name='chevron-left'/>
+        </a>
+        <a href='#' onClick={(this.enableForwardButton(historyCurrentIndex, historyLength) && forward)} 
+          className={cx({'disable': !this.enableForwardButton(historyCurrentIndex, historyLength)})}>
+            <FontAwesome name="chevron-right"/>
+        </a>
+      </div>
+    );
+  };
+}
 
 NavButtons.propTypes = {
   back: PropTypes.func,

--- a/app/components/NavButtons/index.js
+++ b/app/components/NavButtons/index.js
@@ -13,7 +13,7 @@ class NavButtons extends React.Component {
   }
 
   enableBackButton(currentHistoryIndex) {
-    if (currentHistoryIndex == 1) {
+    if (currentHistoryIndex === 1) {
       return false;
     } else {
       return true;
@@ -21,7 +21,7 @@ class NavButtons extends React.Component {
   }
 
   enableForwardButton(currentHistoryIndex, historyLength) {
-    if(currentHistoryIndex == (historyLength - 1)) {
+    if(currentHistoryIndex === (historyLength - 1)) {
       return false;
     } else {
       return true;

--- a/app/components/NavButtons/index.js
+++ b/app/components/NavButtons/index.js
@@ -33,8 +33,8 @@ class NavButtons extends React.Component {
 
     return (
       <div className={styles.nav_buttons}>
-        <a href='#' onClick={(this.enableBackButton(historyLength) && back)} 
-          className={cx({'disable': !this.enableBackButton(historyLength)})}>
+        <a href='#' onClick={(this.enableBackButton(historyCurrentIndex) && back)} 
+          className={cx({'disable': !this.enableBackButton(historyCurrentIndex)})}>
             <FontAwesome name='chevron-left'/>
         </a>
         <a href='#' onClick={(this.enableForwardButton(historyCurrentIndex, historyLength) && forward)} 

--- a/app/components/NavButtons/index.js
+++ b/app/components/NavButtons/index.js
@@ -13,19 +13,11 @@ class NavButtons extends React.Component {
   }
 
   enableBackButton(currentHistoryIndex) {
-    if (currentHistoryIndex === 1) {
-      return !currentHistoryIndex;
-    } else {
-      return currentHistoryIndex;
-    }
+    return currentHistoryIndex > 1;
   }
 
   enableForwardButton(currentHistoryIndex, historyLength) {
-    if(currentHistoryIndex === (historyLength - 1)) {
-      return !currentHistoryIndex;
-    } else {
-      return currentHistoryIndex;
-    }
+    return currentHistoryIndex < (historyLength - 1);
   }
 
   render() {

--- a/app/components/NavButtons/index.js
+++ b/app/components/NavButtons/index.js
@@ -5,13 +5,29 @@ import FontAwesome from 'react-fontawesome';
 import styles from './styles.scss';
 
 const NavButtons = props => {
+
+  let enableBackButton = true;
+  let enableForwardButton = true;
+
+  // Check to see if we are at the dashbashboard of if we cannot go forward anymore to disable buttons
+  console.log("Current index: " + props.historyCurrentIndex)
+  if (props.historyCurrentIndex == 1) {
+    // We need to disable the back button because we can't go back anymore
+    enableBackButton = false;
+  }
+
+  console.log("historyLength: " + props.historyLength)
+  if (props.historyCurrentIndex == (props.historyLength - 1)) {
+    enableForwardButton = false;
+  }
+
   return (
     <div className={styles.nav_buttons}>
-      <a href='#' onClick={props.back} >
-        <FontAwesome name='chevron-left'/>
+      <a href='#' onClick={(enableBackButton ? props.back : null)} className={(enableBackButton ? null : 'disable' )}>
+        {enableBackButton ? <FontAwesome name='chevron-left'/> : <FontAwesome name='chevron-left'/>}
       </a>
-      <a href='#' onClick={props.forward}>
-        <FontAwesome name='chevron-right'/>
+      <a href='#' onClick={(enableForwardButton ? props.forward : null)} className={(enableForwardButton ? null : 'disable')}>
+        {enableForwardButton ? <FontAwesome name="chevron-right"/> : <FontAwesome name='chevron-right'/>}
       </a>
     </div>
   );

--- a/app/components/NavButtons/index.js
+++ b/app/components/NavButtons/index.js
@@ -9,14 +9,10 @@ const NavButtons = props => {
   let enableBackButton = true;
   let enableForwardButton = true;
 
-  // Check to see if we are at the dashbashboard of if we cannot go forward anymore to disable buttons
-  console.log("Current index: " + props.historyCurrentIndex)
   if (props.historyCurrentIndex == 1) {
-    // We need to disable the back button because we can't go back anymore
     enableBackButton = false;
   }
 
-  console.log("historyLength: " + props.historyLength)
   if (props.historyCurrentIndex == (props.historyLength - 1)) {
     enableForwardButton = false;
   }

--- a/app/components/NavButtons/index.js
+++ b/app/components/NavButtons/index.js
@@ -14,17 +14,17 @@ class NavButtons extends React.Component {
 
   enableBackButton(currentHistoryIndex) {
     if (currentHistoryIndex === 1) {
-      return false;
+      return !currentHistoryIndex;
     } else {
-      return true;
+      return currentHistoryIndex;
     }
   }
 
   enableForwardButton(currentHistoryIndex, historyLength) {
     if(currentHistoryIndex === (historyLength - 1)) {
-      return false;
+      return !currentHistoryIndex;
     } else {
-      return true;
+      return currentHistoryIndex;
     }
   }
 
@@ -33,11 +33,11 @@ class NavButtons extends React.Component {
 
     return (
       <div className={styles.nav_buttons}>
-        <a href='#' onClick={(this.enableBackButton(historyCurrentIndex) && back)} 
+        <a href='#' onClick={this.enableBackButton(historyCurrentIndex) ? back : undefined} 
           className={cx({'disable': !this.enableBackButton(historyCurrentIndex)})}>
             <FontAwesome name='chevron-left'/>
         </a>
-        <a href='#' onClick={(this.enableForwardButton(historyCurrentIndex, historyLength) && forward)} 
+        <a href='#' onClick={this.enableForwardButton(historyCurrentIndex, historyLength) ? forward : undefined} 
           className={cx({'disable': !this.enableForwardButton(historyCurrentIndex, historyLength)})}>
             <FontAwesome name="chevron-right"/>
         </a>

--- a/app/components/NavButtons/styles.scss
+++ b/app/components/NavButtons/styles.scss
@@ -1,4 +1,4 @@
-@import "../../vars.scss";
+@import '../../vars.scss';
 
 .nav_buttons {
   display: flex;
@@ -35,6 +35,4 @@
       margin-right: 12px;
     }
   }
-
-
 }

--- a/app/components/NavButtons/styles.scss
+++ b/app/components/NavButtons/styles.scss
@@ -1,4 +1,4 @@
-@import '../../vars.scss';
+@import "../../vars.scss";
 
 .nav_buttons {
   display: flex;
@@ -8,7 +8,7 @@
   margin-left: 12px;
   z-index: 40;
   -webkit-app-region: no-drag;
-  
+
   a {
     display: flex;
     justify-content: center;
@@ -18,11 +18,16 @@
     width: 30px;
     cursor: pointer;
 
-    &:hover {
+    &.disable {
+      opacity: 0.4;
+      cursor: not-allowed;
+    } 
+
+    &:not(.disable):hover {
       background: darken($blue, 10%);
     }
 
-    &:active {
+    &:not(.disable):active {
       background: darken($blue, 15%);
     }
 
@@ -30,4 +35,6 @@
       margin-right: 12px;
     }
   }
+
+
 }


### PR DESCRIPTION
I saw that the back and forward history buttons do not disable when you cannot go back and forwards.

This also prevents when nuclear is loaded to go to the root and display nothing in the main container.

I didn't report this issue because it was an easy fix and I really wanted to contribute something and I knew you would jump on it really quickly since it was so simple.

open to code review