### PR TITLE
feat(error): add a global ErrorBoundary component

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -37,6 +37,7 @@ import IpcContainer from './containers/IpcContainer';
 import SoundContainer from './containers/SoundContainer';
 import ToastContainer from './containers/ToastContainer';
 import ShortcutsContainer from './containers/ShortcutsContainer';
+import ErrorBoundary from './containers/ErrorBoundary';
 
 import ui from 'nuclear-ui';
 import NavButtons from './components/NavButtons';
@@ -274,21 +275,23 @@ class App extends React.Component {
     let { toggleOption } = this.props.actions;
     return (
       <React.Fragment>
-        <div className={styles.app_container}>
-          {this.renderNavBar()}
-          <div className={styles.panel_container}>
-            {this.renderSidebarMenu(settings, toggleOption)}
-            <VerticalPanel className={styles.center_panel}>
-              <MainContentContainer />
-            </VerticalPanel>
-            {this.renderRightPanel(settings)}
-            <ToastContainer/>
-            <ShortcutsContainer/>
+        <ErrorBoundary>
+          <div className={styles.app_container}>
+            {this.renderNavBar()}
+            <div className={styles.panel_container}>
+              {this.renderSidebarMenu(settings, toggleOption)}
+              <VerticalPanel className={styles.center_panel}>
+                <MainContentContainer />
+              </VerticalPanel>
+              {this.renderRightPanel(settings)}
+            </div>
+            {this.renderFooter(settings)}
+            <SoundContainer />
+            <IpcContainer />
           </div>
-          {this.renderFooter(settings)}
-          <SoundContainer />
-          <IpcContainer />
-        </div>
+        </ErrorBoundary>
+        <ShortcutsContainer/>
+        <ToastContainer/>
       </React.Fragment>
     );
   }

--- a/app/containers/ErrorBoundary/index.js
+++ b/app/containers/ErrorBoundary/index.js
@@ -1,0 +1,54 @@
+import logger from 'electron-timber';
+import React from 'react';
+import { withRouter } from 'react-router';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import * as ToastActions from '../../actions/toasts';
+
+const initialState = { hasError: false };
+
+class ErrorBoundary extends React.Component {
+  state = initialState;
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    logger.error(error);
+    this.props.actions.error('error', 'Something wrong happen');
+
+    this.setState({ hasError: true }, () => {
+      this.props.history.goBack();
+      this.setState(initialState);
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}
+
+ErrorBoundary.propTypes = {
+  actions: PropTypes.shape({
+    error: PropTypes.func
+  })
+};
+
+function mapStateToProps() {
+  return {};
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    actions: bindActionCreators(ToastActions, dispatch)
+  };
+}
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ErrorBoundary));

--- a/app/containers/ErrorBoundary/index.js
+++ b/app/containers/ErrorBoundary/index.js
@@ -18,7 +18,7 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch(error) {
     logger.error(error);
-    this.props.actions.error('error', 'Something wrong happen');
+    this.props.actions.error('error', 'Something wrong happened');
 
     this.setState({ hasError: true }, () => {
       this.props.history.goBack();


### PR DESCRIPTION
According to this: https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html
when a component throw an error it should be remove from the tree.

#287 