### PR TITLE
Fix genre background image URI

### DIFF
--- a/app/components/Dashboard/GenresTab/index.js
+++ b/app/components/Dashboard/GenresTab/index.js
@@ -37,7 +37,7 @@ class GenresTab extends React.Component {
                   >
 
                     <div className={styles.genre_overlay}>
-                      <Img src={'https://picsum.photos/256x256/?random&seed=' + i} />
+                      <Img src={'https://picsum.photos/256?random=' + i} />
                     </div>
                     <div className={styles.genre_name}>
                       <div


### PR DESCRIPTION
I agree it does look like they changed something.

Resolves issue #322 

<img width="1563" alt="Screen Shot 2019-04-29 at 3 46 26 PM" src="https://user-images.githubusercontent.com/29871623/56925853-faafb000-6a95-11e9-9b26-0622c48439a8.png">
