### PR TITLE
Allow for custom Youtube search API keys via setting

### DIFF
--- a/app/constants/settings.js
+++ b/app/constants/settings.js
@@ -1,3 +1,4 @@
+import globals from '../globals';
 import settingType from './settingsEnum';
 
 export default [
@@ -73,7 +74,7 @@ export default [
     type: settingType.BOOLEAN,
     prettyName: 'enable-api',
     default: true
-  },  
+  },
   {
     name: 'api.port',
     category: 'http',
@@ -84,6 +85,13 @@ export default [
     max: 49151
   },
   {
+    name: 'yt.apiKey',
+    category: 'youtube',
+    type: settingType.STRING,
+    prettyName: 'yt-api-key',
+    default: globals.ytApiKey
+  },
+  {
     name: 'language',
     category: 'program-settings',
     type: settingType.LIST,
@@ -91,12 +99,12 @@ export default [
     placeholder: 'language-placeholder',
     options: [
       {key: 'en', text: 'English', value: 'en'},
-      {key: 'fr', text: 'French', value: 'fr'}, 
+      {key: 'fr', text: 'French', value: 'fr'},
       {key: 'nl', text: 'Dutch', value: 'nl'},
-      {key: 'de', text: 'German', value: 'de'}, 
-      {key: 'dk', text: 'Danish', value: 'dk'}, 
-      {key: 'es', text: 'Spanish', value: 'es'}, 
-      {key: 'pl', text: 'Polish', value: 'pl'}, 
+      {key: 'de', text: 'German', value: 'de'},
+      {key: 'dk', text: 'Danish', value: 'dk'},
+      {key: 'es', text: 'Spanish', value: 'es'},
+      {key: 'pl', text: 'Polish', value: 'pl'},
       {key: 'zh', text: 'Chinese', value: 'zh'},
       {key: 'ru', text: 'Russian', value: 'ru'},
       {key: 'pt_br', text: 'Português do Brasil', value: 'pt_br'}

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -158,7 +158,9 @@
     "program-settings": "Program settings",
     "shuffle-queue": "Shuffle songs",
     "social": "Social",
-    "user": "User:"
+    "user": "User:",
+    "youtube": "Youtube:",
+    "yt-api-key": "Youtube API Key"
   },
   "tags": {
     "albums": "Top Albums",

--- a/app/rest/youtube-search.js
+++ b/app/rest/youtube-search.js
@@ -1,7 +1,7 @@
-import globals from '../globals';
+import { getOption } from '../persistence/store';
 
 export function prepareUrl (url) {
-  return `${url}&key=${globals.ytApiKey}`;
+  return `${url}&key=${ getOption('yt.apiKey')}`;
 }
 
 export function trackSearch (track) {


### PR DESCRIPTION
Issue:
A number of 403 errors do to API key access limits on the youtube search API. These are reproducible using the released version of the app across all platforms. This is however an issue that can be inconsistent due to the nature of an API request limit and how that limit is reset.

Related Issue:
#362

Fix:
I added a setting to the settings page for the youtube API key. It defaults to the key that exists in the globals file..