### PR TITLE
Equalizer: better styling for narrow screens

### DIFF
--- a/app/components/EqualizerPresetList/styles.scss
+++ b/app/components/EqualizerPresetList/styles.scss
@@ -6,6 +6,9 @@
   flex-flow: column;
   height: 100%;
   flex: 1 1 auto;
+  min-width: 120px;
+  flex-grow: 0;
+  margin-left: 1.5rem;
 
   h3 {
     margin-bottom: 0;
@@ -15,18 +18,30 @@
     @include roundCorners;
     height: 100%;
     overflow: auto;
-    background: $background3;
+    
   }
 
   .equalizer_item {
-    padding: 5px !important;
+    padding: 9px !important;
+    display: flex !important;
+    background: $background2;
+    margin-bottom: 1px;
+    user-select: none;
+    .right {
+      flex-grow: 0;
+      width: 16px;
+      margin-left: 0 !important;
+      margin-right: 9px !important;
+    }
   }
 
   .equalizer_click_item {
+    background: $background3;
     cursor: pointer;
     :hover {
       border-right: solid 2px white;
     }
   }
+  
+  
 }
-

--- a/app/containers/EqualizerViewContainer/styles.scss
+++ b/app/containers/EqualizerViewContainer/styles.scss
@@ -5,7 +5,7 @@
   .equalizer_components {
     display: flex;
     flex-flow: row;
-    padding: 2rem 4rem;
+    padding: 3rem;
     margin-top: 4rem;
   }
 }


### PR DESCRIPTION
Adjusted the styling of the equalizer to make it look better on narrow screens, also moved the selection mark to the left hand side.