### PR TITLE
Fix issue #403 - TrackRow context menu PlayNow button doesn't work since 'DoubleClick' feature

### DIFF
--- a/app/containers/TrackPopupContainer/index.js
+++ b/app/containers/TrackPopupContainer/index.js
@@ -32,7 +32,7 @@ const TrackPopupContainer = props => {
 
   const trackItem = {
     artist,
-    name: props.title,
+    name: title,
     thumbnail: props.thumb
   };
 
@@ -56,7 +56,7 @@ const TrackPopupContainer = props => {
       {
         withPlayNow &&
         <PopupButton
-          onClick={ () => actions.playSong(musicSources, trackItem) }
+          onClick={ () => actions.playTrack(musicSources, trackItem) }
           ariaLabel='Play this track now'
           icon='play'
           label='Play now'


### PR DESCRIPTION
My doubleclick PR caused a bug (#403). This fixes it.

