### PR TITLE
Remove explicit Lato font family

### DIFF
--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -6,7 +6,6 @@ html {
   height: 100%;
   cursor: default;
   -webkit-user-select: none;
-  font-family: 'Lato';
 }
 
 body {

--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -6,6 +6,7 @@ html {
   height: 100%;
   cursor: default;
   -webkit-user-select: none;
+  font-family: Lato, 'Helvetica Neue', Arial, Helvetica, sans-serif;
 }
 
 body {

--- a/app/components/SearchBox/styles.scss
+++ b/app/components/SearchBox/styles.scss
@@ -44,9 +44,7 @@
   outline: none;
   background-color: $background3;
 
-  font-family: Lato;
   font-size: 16px;
-
   flex: 1 1 auto;
 }
 


### PR DESCRIPTION
Semantic UI library used defines its own CSS font stack, which has sensible fallbacks for Russian and other languages, so without these declarations at least the search bar looks way better.