### PR TITLE
Got rid of high CPU usage when idling

### DIFF
--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -17,7 +17,7 @@ body {
 }
 
 body.dimmed {
-  #react_root {
+  #react-root {
     height: 100%;
   }
 }

--- a/app/index.js
+++ b/app/index.js
@@ -29,7 +29,7 @@ const render = async Component => {
         </Provider>
       </I18nextProvider>
     </AppContainer>,
-    document.getElementById('react_root')
+    document.getElementById('react-root')
   );
 };
 

--- a/index.html
+++ b/index.html
@@ -86,12 +86,13 @@
     </style>
   </head>
   <body>
-    <div id="react_root"></div>
-    <div class="loader-container">
-      <div class="nuclear-loader">
-        <span></span>
-        <span></span>
-        <span></span>
+    <div id="react-root">
+      <div class="loader-container">
+        <div class="nuclear-loader">
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
       </div>
     </div>
   </body>

--- a/index.prod.html
+++ b/index.prod.html
@@ -14,14 +14,16 @@
 </head>
 <body>
 
-  <div id="react_root"></div>
-  <div class="loader-container">
-    <div class="nuclear-loader">
-      <span></span>
-      <span></span>
-      <span></span>
+  <div id="react-root">
+    <div class="loader-container">
+      <div class="nuclear-loader">
+        <span></span>
+        <span></span>
+        <span></span>
+      </div>
     </div>
   </div>
+  
 
   
 </body>


### PR DESCRIPTION
Nuclear used to consume a considerable CPU time due to the animated "loader" being rendered in the background. I changed the HTML to make it completely disappear upon first render.