### PR TITLE
#489 Disabling more queue options if queue is empty

### DIFF
--- a/packages/app/app/components/PlayQueue/QueueMenu/QueueMenuMore/index.js
+++ b/packages/app/app/components/PlayQueue/QueueMenu/QueueMenuMore/index.js
@@ -16,6 +16,7 @@ const addTrackToPlaylist = (updatePlaylist, playlist, track) => {
 };
 
 const QueueMenuMore = ({
+  disabled,
   clearQueue,
   savePlaylistDialog,
   addFavoriteTrack,
@@ -29,7 +30,7 @@ const QueueMenuMore = ({
   const { t } = useTranslation('queue');
 
   return (
-    <Dropdown item icon='ellipsis vertical' className={styles.queue_menu_more}>
+    <Dropdown item icon='ellipsis vertical' className={styles.queue_menu_more} disabled={disabled}>
       <Dropdown.Menu>
         <Dropdown.Header>{t('header')}</Dropdown.Header>
         <Dropdown.Item onClick={clearQueue}>
@@ -75,6 +76,7 @@ const QueueMenuMore = ({
 };
 
 QueueMenuMore.propTypes = {
+  disabled: PropTypes.bool,
   clearQueue: PropTypes.func,
   addFavoriteTrack: PropTypes.func,
   addToDownloads: PropTypes.func,
@@ -85,6 +87,7 @@ QueueMenuMore.propTypes = {
 };
 
 QueueMenuMore.defaultProps = {
+  disabled: true,
   clearQueue: () => {},
   addFavoriteTrack: () => {},
   addToDownloads: () => {},

--- a/packages/app/app/components/PlayQueue/QueueMenu/index.js
+++ b/packages/app/app/components/PlayQueue/QueueMenu/index.js
@@ -59,7 +59,7 @@ class QueueMenu extends React.Component {
           {
             !compact &&
               <QueueMenuMore
-                disabled={!items.length}
+                disabled={_.isEmpty(items)}
                 clearQueue={clearQueue}
                 updatePlaylist={updatePlaylist}
                 addFavoriteTrack={addFavoriteTrack}

--- a/packages/app/app/components/PlayQueue/QueueMenu/index.js
+++ b/packages/app/app/components/PlayQueue/QueueMenu/index.js
@@ -59,6 +59,7 @@ class QueueMenu extends React.Component {
           {
             !compact &&
               <QueueMenuMore
+                disabled={!items.length}
                 clearQueue={clearQueue}
                 updatePlaylist={updatePlaylist}
                 addFavoriteTrack={addFavoriteTrack}

--- a/packages/app/test/enzyme.queuemenu.test.js
+++ b/packages/app/test/enzyme.queuemenu.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import chai from 'chai';
+import { mount } from 'enzyme';
+import { describe, it } from 'mocha';
+
+import QueueMenu from '../app/components/PlayQueue/QueueMenu';
+import QueueMenuMore from '../app/components/PlayQueue/QueueMenu/QueueMenuMore';
+
+const { expect } = chai;
+
+describe('<QueueMenu /> Empty', () => {
+    it('Should disable more options if there are no queue items', () => {
+        const queueMenu = mount(<QueueMenu items={[]} settings={{compactQueueBar: true }} compact={false}/>);
+        const queueMenuMore = queueMenu.find(QueueMenuMore);
+        expect(queueMenuMore.prop('disabled')).to.be.true;
+
+    })
+})
+

--- a/packages/app/test/enzyme.queuemenumore.test.js
+++ b/packages/app/test/enzyme.queuemenumore.test.js
@@ -37,7 +37,7 @@ describe('<QueueMenuMore /> Playlist button', () => {
 describe('<QueueMenuMore /> Add favorite track button', () => {
   it('Has star icon and addFavoriteTrack fired on click of playlist item', () => {
     const spy = chai.spy();
-    const wrapper = mount(<QueueMenuMore addFavoriteTrack={spy} playlists={[1]}/>);
+    const wrapper = mount(<QueueMenuMore addFavoriteTrack={spy} playlists={[1]} currentItem={{name: 'test'}}/>);
     const favItem = wrapper.find(Dropdown.Item).at(3);
 
     favItem.simulate('click');


### PR DESCRIPTION
Resolves #489.

Previously, a file would be downloaded even if the queue was empty. This has already been resolved with https://github.com/nukeop/nuclear/commit/f43012b3aa6e26e549d23d1173f29c329a6b8db4, so this is a UX change to disable the entire options menu if the queue is empty.

First PR. Looking for any feedback. 👍 