### PR TITLE
Issue #491: Added en-US option for settings language dropdown

### DIFF
--- a/packages/app/common/settings.js
+++ b/packages/app/common/settings.js
@@ -125,6 +125,7 @@ export default [
       { key: 'de', text: 'Deutsch', value: 'de' },
       { key: 'dk', text: 'Dansk', value: 'dk' },
       { key: 'en', text: 'English', value: 'en' },
+      { key: 'en-US', text: 'English (US)', value: 'en-US' },
       { key: 'es', text: 'Español', value: 'es' },
       { key: 'fr', text: 'Français', value: 'fr' },
       { key: 'it', text: 'Italiano', value: 'it' },


### PR DESCRIPTION
Fix for Issue #491: Automatically choose translation based on locale. 

Added en-US option for settings language dropdown so that i18n `languageChanged` callback sets the language option to a valid key while using `en-US` locale. 