### PR TITLE
Display stream id only if exist

### DIFF
--- a/packages/app/app/components/QueuePopup/index.js
+++ b/packages/app/app/components/QueuePopup/index.js
@@ -102,13 +102,11 @@ class QueuePopup extends React.Component {
             <label>{t('title')}</label>
             <span>{selectedStream.title}</span>
           </div>
-          {selectedStream.id ? (
+          {selectedStream.id && (
             <div className={styles.stream_id}>
               <label>{t('id')}</label>
               <span>{selectedStream.id}</span>
             </div>
-          ) : (
-            null
           )}
         </div>
         {this.renderStreamRefreshButton()}

--- a/packages/app/app/components/QueuePopup/index.js
+++ b/packages/app/app/components/QueuePopup/index.js
@@ -102,10 +102,14 @@ class QueuePopup extends React.Component {
             <label>{t('title')}</label>
             <span>{selectedStream.title}</span>
           </div>
-          <div className={styles.stream_id}>
-            <label>{t('id')}</label>
-            <span>{selectedStream.id}</span>
-          </div>
+          {selectedStream.id ? (
+            <div className={styles.stream_id}>
+              <label>{t('id')}</label>
+              <span>{selectedStream.id}</span>
+            </div>
+          ) : (
+            null
+          )}
         </div>
         {this.renderStreamRefreshButton()}
       </div>


### PR DESCRIPTION
The stream Id was always displayed on the stream info, regardless the track has one or not.

| Before | <img src="https://user-images.githubusercontent.com/35188982/66469735-aff48400-ea88-11e9-8d8b-ed84ba54898a.png" width="450"></img>|                                                                                                                  
|:------:|:----------------------------------------------------------------------------------------------------:|
| **After** | <img src="https://user-images.githubusercontent.com/35188982/66469830-e92cf400-ea88-11e9-92d2-bd1a9bc793ca.png" width="450"></img> |
