### PR TITLE
Use https instead of http

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,8 @@ Last.fm augments data returned by Discogs by adding extra information. When you 
 | Site        | Website                                              |
 |-------------|------------------------------------------------------|
 | Github      | <https://github.com/nukeop/nuclear>                  |
-| ReadTheDocs | <https://nuclearmusic.rtfd.io>                        |
+| ReadTheDocs | <https://nuclearmusic.rtfd.io>                       |
 | Mastodon    | <https://mstdn.io/@nuclear>                          |
-| Twitter     | <https://twitter.com/nuclear_player>                  |
+| Twitter     | <https://twitter.com/nuclear_player>                 |
 | Beerpay     | <https://beerpay.io/nukeop/nuclear>                  |
 | AUR         | <https://aur.archlinux.org/packages/nuclear-player/> |

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,8 @@ Last.fm augments data returned by Discogs by adding extra information. When you 
 | Site        | Website                                              |
 |-------------|------------------------------------------------------|
 | Github      | <https://github.com/nukeop/nuclear>                  |
-| ReadTheDocs | <http://nuclearmusic.rtfd.io>                        |
+| ReadTheDocs | <https://nuclearmusic.rtfd.io>                        |
 | Mastodon    | <https://mstdn.io/@nuclear>                          |
-| Twitter     | <http://twitter.com/nuclear_player>                  |
+| Twitter     | <https://twitter.com/nuclear_player>                  |
 | Beerpay     | <https://beerpay.io/nukeop/nuclear>                  |
 | AUR         | <https://aur.archlinux.org/packages/nuclear-player/> |

--- a/packages/app/app/actions/scrobbling.js
+++ b/packages/app/app/actions/scrobbling.js
@@ -44,7 +44,7 @@ export function lastFmConnectAction() {
       .then(response => {
         let authToken = response.token;
         electron.shell.openExternal(
-          'http://www.last.fm/api/auth/?api_key=' + globals.lastfmApiKey + '&token=' + authToken
+          'https://www.last.fm/api/auth/?api_key=' + globals.lastfmApiKey + '&token=' + authToken
         );
 
         store.set('lastFm.lastFmAuthToken', authToken);

--- a/packages/app/app/mocks/queueMock.js
+++ b/packages/app/app/mocks/queueMock.js
@@ -10,7 +10,7 @@ export const queueData = [
     name: 'Joe\'s Garage'
   },
   {
-    thumbnail: 'http://3.bp.blogspot.com/_aNTsUIQhmf0/TJD02nFCD0I/AAAAAAAADyc/nEs2_ttp98c/s1600/Neutral+Milk+Hotel+-+In+the+Aeroplane+Over+the+Sea+-+1998.jpg',
+    thumbnail: 'https://3.bp.blogspot.com/_aNTsUIQhmf0/TJD02nFCD0I/AAAAAAAADyc/nEs2_ttp98c/s1600/Neutral+Milk+Hotel+-+In+the+Aeroplane+Over+the+Sea+-+1998.jpg',
     artist: 'Neutral Milk Hotel',
     name: 'The King of Carrot Flowers Pts. Two & Three'
   }

--- a/packages/app/app/plugins/stream/YoutubePlugin.js
+++ b/packages/app/app/plugins/stream/YoutubePlugin.js
@@ -20,7 +20,7 @@ class YoutubePlugin extends StreamProviderPlugin {
       .then(results => {
         let song = _.head(results.items);
         let id = song.id.videoId;
-        return ytdl.getInfo(`http://www.youtube.com/watch?v=${id}`);
+        return ytdl.getInfo(`https://www.youtube.com/watch?v=${id}`);
       })
       .then(videoInfo => {
         let thumbnail = _.get(videoInfo, 'player_response.videoDetails.thumbnail.thumbnails');
@@ -50,7 +50,7 @@ class YoutubePlugin extends StreamProviderPlugin {
           return item && item.id.videoId !== currentStream.id;
         });
         let id = song.id.videoId;
-        return ytdl.getInfo(`http://www.youtube.com/watch?v=${id}`);
+        return ytdl.getInfo(`https://www.youtube.com/watch?v=${id}`);
       })
       .then(videoInfo => {
         let formatInfo = _.head(videoInfo.formats.filter(e => e.itag === '140'));

--- a/packages/app/app/rest/CoverArtArchive.js
+++ b/packages/app/app/rest/CoverArtArchive.js
@@ -1,4 +1,4 @@
-const apiUrl = 'http://coverartarchive.org/';
+const apiUrl = 'https://coverartarchive.org/';
 
 function releaseGroupFront(group, size=250) {
   return new Promise(fulfill => {

--- a/packages/app/app/rest/Nuclear.js
+++ b/packages/app/app/rest/Nuclear.js
@@ -1,6 +1,6 @@
 import logger from 'electron-timber';
 
-const nuclearNewsUrl = 'http://nuclear.js.org/news/';
+const nuclearNewsUrl = 'https://nuclear.js.org/news/';
 
 export function getNewsIndex() {
   return fetch(nuclearNewsUrl)

--- a/packages/app/server/downloads.js
+++ b/packages/app/server/downloads.js
@@ -15,12 +15,12 @@ export const registerDownloadsEvents = window => {
   ipcMain.once('started', event => {
     rendererWindow = event.sender;
   });
-  
+
   ipcMain.on('start-download', (event, data) => {
     const artistName = _.isString(_.get(data, 'artist'))
       ? _.get(data, 'artist')
       : _.get(data, 'artist.name');
-    
+
     const query = `${artistName} ${_.get(data, 'name')}`;
     const filename = `${artistName} - ${_.get(data, 'name')}`;
 
@@ -31,12 +31,12 @@ export const registerDownloadsEvents = window => {
       .then(results => results.json())
       .then(ytData => {
         const trackId = _.get(_.head(ytData.items), 'id.videoId');
-        return ytdl.getInfo(`http://www.youtube.com/watch?v=${trackId}`);
+        return ytdl.getInfo(`https://www.youtube.com/watch?v=${trackId}`);
       })
       .then(videoInfo => {
         const formatInfo = _.head(videoInfo.formats.filter(e => e.itag === '140'));
         const streamUrl = formatInfo.url;
-        
+
         return download(window, streamUrl, {
           filename: filename + `.${_.get(formatInfo, 'container')}`,
           directory: getOption('downloads.dir'),
@@ -59,6 +59,6 @@ export const registerDownloadsEvents = window => {
         logger.error(error);
         rendererWindow.send('download-error', { uuid: data.uuid, error });
       });
-    
+
   });
 };

--- a/packages/core/lib/rest/lastfm.js
+++ b/packages/core/lib/rest/lastfm.js
@@ -1,6 +1,6 @@
 import md5 from 'md5';
 
-const scrobblingApiUrl = 'http://ws.audioscrobbler.com/2.0/';
+const scrobblingApiUrl = 'https://ws.audioscrobbler.com/2.0/';
 
 class LastFmApi {
   constructor(key, secret) {


### PR DESCRIPTION
Some links were still in http, while sites support and redirect to https. There is no reason to stay in http. 