### PR TITLE
fix min size of the steam info

### DIFF
--- a/packages/app/app/components/QueuePopup/styles.scss
+++ b/packages/app/app/components/QueuePopup/styles.scss
@@ -18,6 +18,7 @@
   .stream_info {
     position: relative;
     display: block;
+    min-width: 124px;
   }
 
   .stream_text_info {


### PR DESCRIPTION
As the stream_info takes the size on the background image, when the thumbnails are smaller than 124px, not all the information can be displayed properly. 124px comes from the size of a thumbnail of a Youtube music.

| Before | <img src="https://user-images.githubusercontent.com/35188982/66495861-44c3a580-eaba-11e9-9b66-c1c922c386a2.png" width="150px"></img>
|---------| --------------------------------------------------------------------------------------------------------------------------------------------------------|
| **After** | <img src="https://user-images.githubusercontent.com/35188982/66495884-4c834a00-eaba-11e9-9f0f-d207eaeb813e.png" width="150px"></img> |
