### PR TITLE
(#500) Update react-beautiful-dnd and improved drag functionality

### DIFF
--- a/packages/app/app/actions/queue.js
+++ b/packages/app/app/actions/queue.js
@@ -11,7 +11,7 @@ export const REPLACE_STREAMS_IN_QUEUE_ITEM = 'REPLACE_STREAMS_IN_QUEUE_ITEM';
 export const NEXT_SONG = 'NEXT_SONG';
 export const PREVIOUS_SONG = 'PREVIOUS_SONG';
 export const SELECT_SONG = 'SELECT_SONG';
-export const SWAP_SONGS = 'SWAP_SONGS';
+export const REPOSITION_SONG = 'REPOSITION_SONG';
 
 function addTrackToQueue (musicSources, item) {
   return dispatch => {
@@ -104,9 +104,9 @@ export function selectSong (index) {
   };
 }
 
-export function swapSongs (itemFrom, itemTo) {
+export function repositionSong (itemFrom, itemTo) {
   return {
-    type: SWAP_SONGS,
+    type: REPOSITION_SONG,
     payload: {
       itemFrom,
       itemTo

--- a/packages/app/app/components/PlayQueue/index.js
+++ b/packages/app/app/components/PlayQueue/index.js
@@ -54,7 +54,7 @@ class PlayQueue extends React.Component {
 
     return this.props.items.map((el, i) => {
       return (
-        <Draggable key={i} index={i} draggableId={`${i}`}>
+        <Draggable key={el.uuid} index={i} draggableId={el.uuid}>
           {(provided) => (
             <div
               ref={provided.innerRef}

--- a/packages/app/app/components/PlayQueue/index.js
+++ b/packages/app/app/components/PlayQueue/index.js
@@ -19,6 +19,13 @@ class PlayQueue extends React.Component {
   }
 
   onDragEnd(result) {
+
+    const { source, destination } = result;
+    // when dragging to non droppable area or back to same position
+    if (!destination || source.index == destination.index) {
+      return;
+    }
+
     this.props.actions.swapSongs(result.source.index, result.destination.index);
   }
 
@@ -47,7 +54,7 @@ class PlayQueue extends React.Component {
 
     return this.props.items.map((el, i) => {
       return (
-        <Draggable key={i} index={i} draggableId={i}>
+        <Draggable key={i} index={i} draggableId={`${i}`}>
           {(provided) => (
             <div
               ref={provided.innerRef}

--- a/packages/app/app/components/PlayQueue/index.js
+++ b/packages/app/app/components/PlayQueue/index.js
@@ -26,7 +26,7 @@ class PlayQueue extends React.Component {
       return;
     }
 
-    this.props.actions.swapSongs(result.source.index, result.destination.index);
+    this.props.actions.repositionSong(result.source.index, result.destination.index);
   }
 
   onAddToDownloads(track) {

--- a/packages/app/app/reducers/queue.js
+++ b/packages/app/app/reducers/queue.js
@@ -80,7 +80,12 @@ function reduceRepositionSong(state, action) {
   newQueue = _.cloneDeep(state.queueItems);
   const [removed] = newQueue.splice(action.payload.itemFrom, 1);
   newQueue.splice(action.payload.itemTo, 0, removed)
+
+  const oldCurrentSong = state.queueItems[state.currentSong];
+  const newCurrentSong = findQueueItemIndex(newQueue, oldCurrentSong)
+
   return Object.assign({}, state, {
+    currentSong: newCurrentSong,
     queueItems: newQueue
   });
 }

--- a/packages/app/app/reducers/queue.js
+++ b/packages/app/app/reducers/queue.js
@@ -7,7 +7,7 @@ import {
   NEXT_SONG,
   PREVIOUS_SONG,
   SELECT_SONG,
-  SWAP_SONGS
+  REPOSITION_SONG
 } from '../actions/queue';
 
 let _ = require('lodash');
@@ -75,12 +75,11 @@ function reduceSelectSong(state, action) {
   });
 }
 
-function reduceSwapSongs(state, action) {
+function reduceRepositionSong(state, action) {
   let newQueue;
   newQueue = _.cloneDeep(state.queueItems);
-  let temp = newQueue[action.payload.itemFrom];
-  newQueue[action.payload.itemFrom] = newQueue[action.payload.itemTo];
-  newQueue[action.payload.itemTo] = temp;
+  const [removed] = newQueue.splice(action.payload.itemFrom, 1);
+  newQueue.splice(action.payload.itemTo, 0, removed)
   return Object.assign({}, state, {
     queueItems: newQueue
   });
@@ -119,8 +118,8 @@ export default function QueueReducer(state = initialState, action) {
     return reducePreviousSong(state);
   case SELECT_SONG:
     return reduceSelectSong(state, action);
-  case SWAP_SONGS:
-    return reduceSwapSongs(state, action);
+  case REPOSITION_SONG:
+    return reduceRepositionSong(state, action);
   default:
     return state;
   }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -76,7 +76,7 @@
     "numeral": "^2.0.6",
     "pitchfork-bnm": "^1.0.3",
     "react": "^16.8.6",
-    "react-beautiful-dnd": "^9.0.0",
+    "react-beautiful-dnd": "^11.0.0",
     "react-dom": "^16.8.6",
     "react-hifi": "^2.1.2",
     "react-i18next": "^10.11.0",

--- a/packages/app/test/reorder.test.js
+++ b/packages/app/test/reorder.test.js
@@ -1,0 +1,70 @@
+import QueueReducer from '../app/reducers/queue';
+import { REPOSITION_SONG } from '../app/actions/queue';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+describe('Reorder Reducer Test', () => {
+    it('should not change anything for a queue of length 1', () => {
+        const initialState = { currentSong: 0, queueItems: [{ uuid: "first"}]}
+        const action = {
+            type: REPOSITION_SONG,
+            payload: {
+                itemFrom: 0,
+                itemTo: 0
+            }
+        }
+        const finalState = QueueReducer(initialState, action);
+
+        expect(finalState.currentSong).to.equal(0);
+        expect(finalState.queueItems.length).to.equal(1)
+        expect(finalState.queueItems[0].uuid).to.equal("first")
+
+    })
+
+
+    it('should move the current song to where it is dragged', () => {
+        const initialState = { 
+            currentSong: 0, 
+            queueItems: [ {uuid: "first"},  {uuid: "second"},  {uuid: "third"}]
+        }
+        const moveToLastAction = {
+            type: REPOSITION_SONG,
+            payload: {
+                itemFrom: 0,
+                itemTo: 2
+            }
+        }
+
+        const intermediateState = QueueReducer(initialState, moveToLastAction);
+        expect(intermediateState.currentSong).to.equal(2);
+
+        const moveToMiddleAction = {
+            type: REPOSITION_SONG,
+            payload: {
+                itemFrom: 2,
+                itemTo: 1
+            }
+        }
+
+        const finalState = QueueReducer(intermediateState, moveToMiddleAction);
+        expect(finalState.currentSong).to.equal(1);
+        
+    })
+
+    it('should reposition the current song if adjacent songs are moved', () => {
+        const initialState = { 
+            currentSong: 1, 
+            queueItems: [ {uuid: "first"},  {uuid: "second"},  {uuid: "third"}]
+        }
+        const action = {
+            type: REPOSITION_SONG,
+            payload: {
+                itemFrom: 0,
+                itemTo: 2
+            }
+        }
+        const finalState = QueueReducer(initialState, action);
+        expect(finalState.currentSong).to.equal(0);
+    })
+
+})

--- a/packages/ui/lib/components/QueueItem/styles.scss
+++ b/packages/ui/lib/components/QueueItem/styles.scss
@@ -1,7 +1,6 @@
 @import '../../common.scss';
 
 .queue_item {
-  @include transition;
   @include roundCorners;
 
   display: flex;
@@ -10,8 +9,6 @@
   height: 4em;
   margin: 0.5em;
   background-color: rgba($background2, 0.5);
-
-  animation: queue_item_fade_in 0.5s;
 
   .thumbnail {
     @include center;
@@ -86,14 +83,4 @@
 
 .current_song {
   background: rgba($green, 0.3);
-}
-
-@keyframes queue_item_fade_in {
-  0% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
 }


### PR DESCRIPTION
-resolves #500 
-updated react-beautiful-dnd from v9 to v11
-improved drag functionality (before, songs would be reordered unpredictably because it was only swapping the source and destination)
-dragging the currently playing song will now not change it (before, the currently playing song would remain at its index)
-removed the fade in animation for queue items