### PR TITLE
Comparing the song name instead of the whole track object 

### DIFF
--- a/packages/app/app/components/TrackRow/index.js
+++ b/packages/app/app/components/TrackRow/index.js
@@ -53,7 +53,7 @@ class TrackRow extends React.Component {
 
   canAddToFavorites() {
     return _.findIndex(this.props.favoriteTracks, (currentTrack) => {
-      return _.isMatch(currentTrack, this.props.track);
+      return currentTrack.name == this.props.track.name
     }) < 0;
   }
 

--- a/packages/app/app/components/TrackRow/index.js
+++ b/packages/app/app/components/TrackRow/index.js
@@ -53,7 +53,7 @@ class TrackRow extends React.Component {
 
   canAddToFavorites() {
     return _.findIndex(this.props.favoriteTracks, (currentTrack) => {
-      return currentTrack.name == this.props.track.name
+      return currentTrack.name === this.props.track.name && currentTrack.artist.name === this.props.track.artist.name
     }) < 0;
   }
 


### PR DESCRIPTION
This should help with adding duplicated tracks to favorites. The isMatch function was comparing the entire track objects which would not necessarily be deeply equal due to the play count or whatever. It should be sufficient to compare just the song name and that would be the check to whether you can add this track to your favorites or not