### PR TITLE
fix french translation

### DIFF
--- a/packages/app/app/locales/fr.json
+++ b/packages/app/app/locales/fr.json
@@ -34,7 +34,7 @@
     "best-new-tracks": "Meilleurs morceaux",
     "genres": "Genres",
     "lastfm-title": "Meilleurs morceaux de LastFm.",
-    "news": "Nouveautés",
+    "news": "Actualités",
     "playcounts": "Nombre d'écoute",
     "title": "Titre",
     "top": "Top Tracks"


### PR DESCRIPTION
"best" and "news" on the dashboard had the same translation. It was confusing and display an unnecessary error in the console.