### PR TITLE
improve source fallback

### DIFF
--- a/packages/app/app/utils.js
+++ b/packages/app/app/utils.js
@@ -38,7 +38,13 @@ export function getSelectedStream(streams, defaultMusicSource) {
   let selectedStream = _.find(streams, { source: defaultMusicSource });
 
   return typeof selectedStream === 'undefined'
-    ? streams ? streams[0] : null
+    ? (streams
+      ? (streams[0]
+        ? streams[0]
+        : (streams[1]
+          ? streams[1]
+          : null))
+      : null)
     : selectedStream;
 }
 

--- a/packages/app/app/utils.js
+++ b/packages/app/app/utils.js
@@ -37,15 +37,9 @@ export function stringDurationToSeconds(duration) {
 export function getSelectedStream(streams, defaultMusicSource) {
   let selectedStream = _.find(streams, { source: defaultMusicSource });
 
-  return typeof selectedStream === 'undefined'
-    ? (streams
-      ? (streams[0]
-        ? streams[0]
-        : (streams[1]
-          ? streams[1]
-          : null))
-      : null)
-    : selectedStream;
+  return _.isNil(selectedStream)
+   ? _.filter(streams, 'source')[0] || null
+   : selectedStream;
 }
 
 export function removeQuotes(text) {


### PR DESCRIPTION
If there is no selectedStream, we just try to use Youtube as a source. This means that music only on Soundcloud cannot be played without changing the favorite music source in the plugin settings. And as "favorite music source" says in the name, the software should use the favorite source, but automatically use the other sources if the favorite one is not available. I've used a bit the software with the modification, and it works perfectly.