### PR TITLE
Fix drag behavior when songs with same ID are in the play queue

### DIFF
--- a/packages/app/app/components/PlayQueue/index.js
+++ b/packages/app/app/components/PlayQueue/index.js
@@ -54,7 +54,7 @@ class PlayQueue extends React.Component {
 
     return this.props.items.map((el, i) => {
       return (
-        <Draggable key={el.uuid} index={i} draggableId={el.uuid}>
+        <Draggable key={`${el.uuid}+${i}`} index={i} draggableId={`${el.uuid}+${i}`}>
           {(provided) => (
             <div
               ref={provided.innerRef}

--- a/packages/app/app/reducers/queue.js
+++ b/packages/app/app/reducers/queue.js
@@ -81,8 +81,25 @@ function reduceRepositionSong(state, action) {
   const [removed] = newQueue.splice(action.payload.itemFrom, 1);
   newQueue.splice(action.payload.itemTo, 0, removed)
 
-  const oldCurrentSong = state.queueItems[state.currentSong];
-  const newCurrentSong = findQueueItemIndex(newQueue, oldCurrentSong)
+
+  let newCurrentSong = state.currentSong;
+  if (action.payload.itemFrom == state.currentSong) {
+    newCurrentSong = action.payload.itemTo;
+  } else if (action.payload.itemFrom < action.payload.itemTo) {
+    // moving top to bottom and
+    // current song is in between
+    if (state.currentSong > action.payload.itemFrom && state.currentSong <= action.payload.itemTo) {
+      newCurrentSong--;
+    }
+  } 
+  else if (action.payload.itemFrom > action.payload.itemTo) {
+    // moving bottom to top
+    // current song is in between
+    if (state.currentSong < action.payload.itemFrom && state.currentSong >= action.payload.itemTo) {
+      newCurrentSong++;
+    }
+  }
+  // otherwise does not change
 
   return Object.assign({}, state, {
     currentSong: newCurrentSong,


### PR DESCRIPTION
-fixed dragging causing issues when the id's are the same
![dup](https://user-images.githubusercontent.com/8953212/66723429-165e0700-ede7-11e9-9788-95b0bd0bcbe5.gif)

-improved repositioning logic so finding where the current song is in constant time instead of linear search