### PR TITLE
Improvements to the local library feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "build:all": "cd packages/app && npm run build:dist && npm run build:electron && npm run build:all"
   },
   "dependencies": {
-    "eslint": "^6.5.1",
-    "tiny-async-pool": "^1.0.4"
+    "eslint": "^6.5.1"
   },
   "devDependencies": {
     "lerna": "^3.16.4"

--- a/package.json
+++ b/package.json
@@ -30,10 +30,14 @@
     "build:all": "cd packages/app && npm run build:dist && npm run build:electron && npm run build:all"
   },
   "dependencies": {
-    "eslint": "^6.5.1"
+    "eslint": "^6.5.1",
+    "tiny-async-pool": "^1.0.4"
   },
   "devDependencies": {
     "lerna": "^3.16.4"
   },
-  "engines" : { "node" : ">=0.11.0", "npm": ">=6.0.0" }
+  "engines": {
+    "node": ">=0.11.0",
+    "npm": ">=6.0.0"
+  }
 }

--- a/packages/app/app/actions/local.js
+++ b/packages/app/app/actions/local.js
@@ -5,6 +5,7 @@ import { refreshLocalFolders } from '../mpris';
 export const ADD_LOCAL_FOLDERS = 'ADD_LOCAL_FOLDER';
 export const REMOVE_LOCAL_FOLDER = 'REMOVE_LOCAL_FOLDER';
 export const SCAN_LOCAL_FOLDER = 'SCAN_LOCAL_FOLDERS';
+export const SCAN_LOCAL_FOLDER_PROGRESS = 'SCAN_LOCAL_FOLDER_PROGRESS';
 export const SCAN_LOCAL_FOLDER_SUCCESS = 'SCAN_LOCAL_FOLDER_SUCCESS';
 export const SCAN_LOCAL_FOLDER_FAILED = 'SCAN_LOCAL_FOLDER_FAILED';
 export const OPEN_LOCAL_FOLDER_PICKER = 'OPEN_LOCAL_FOLDER_PICKER';
@@ -30,6 +31,16 @@ export function scanLocalFolders() {
 
   return {
     type: SCAN_LOCAL_FOLDER
+  };
+}
+
+export function scanLocalFoldersProgress(scanProgress, scanTotal) {
+  return {
+    type: SCAN_LOCAL_FOLDER_PROGRESS,
+    payload: {
+      scanProgress,
+      scanTotal
+    }
   };
 }
 

--- a/packages/app/app/components/LibraryView/index.js
+++ b/packages/app/app/components/LibraryView/index.js
@@ -7,6 +7,7 @@ import {
   Icon,
   Input,
   List,
+  Progress,
   Segment,
   Table
 } from 'semantic-ui-react';
@@ -25,6 +26,8 @@ const LibraryView = ({
   tracks,
   actions,
   pending,
+  scanProgress,
+  scanTotal,
   localFolders,
   sortBy,
   direction,
@@ -42,24 +45,29 @@ const LibraryView = ({
     <div className={styles.local_files_view}>
       <Header>{t('header')}</Header>
       <Segment>
-        <Button
-          icon
-          inverted
-          labelPosition='left'
-          className={styles.add_folder}
-          onClick={actions.openLocalFolderPicker}
-        >
-          <Icon name='folder open' />
-          {t('add')}
-        </Button>
-        <Button
-          inverted
-          icon='refresh'
-          disabled={localFolders.length < 1}
-          loading={pending}
-          onClick={actions.scanLocalFolders}
-          className={styles.refresh_icon}
-        />
+        <Segment className={styles.control_bar}>
+          <Button
+            icon
+            inverted
+            labelPosition='left'
+            className={styles.add_folder}
+            onClick={actions.openLocalFolderPicker}
+          >
+            <Icon name='folder open' />
+            {t('add')}
+          </Button>
+          <Button
+            inverted
+            icon='refresh'
+            disabled={localFolders.length < 1}
+            loading={pending}
+            onClick={actions.scanLocalFolders}
+            className={styles.refresh_icon}
+          />
+          {scanTotal && (
+            <Progress className={styles.progress_bar} value={scanProgress} total={scanTotal} progress='ratio' />
+          )}
+        </Segment>
         {localFolders.length > 0 &&
           <>
             <Divider />

--- a/packages/app/app/components/LibraryView/index.scss
+++ b/packages/app/app/components/LibraryView/index.scss
@@ -5,9 +5,19 @@
   display: flex;
   flex-flow: column;
 
+  .control_bar {
+    display: flex;
+  }
+
   .refresh_icon {
     margin-left: 10px !important;
     cursor: pointer;
+  }
+
+  .progress_bar {
+    display: inline-block;
+    flex: 1;
+    margin: auto 0 auto 10px !important;
   }
 
   .folder_remove_icon {

--- a/packages/app/app/containers/IpcContainer/index.js
+++ b/packages/app/app/containers/IpcContainer/index.js
@@ -31,6 +31,7 @@ import {
   onRefreshPlaylists,
   onUpdateEqualizer,
   onSetEqualizer,
+  onLocalFilesProgress,
   onLocalFiles,
   onLocalFilesError
 } from '../../mpris';
@@ -56,6 +57,7 @@ class IpcContainer extends React.Component {
     ipcRenderer.on('refresh-playlists', (event) => onRefreshPlaylists(event, this.props.actions));
     ipcRenderer.on('update-equalizer', (event, data) =>  onUpdateEqualizer(event, this.props.actions, data));
     ipcRenderer.on('set-equalizer', (event, data) => onSetEqualizer(event, this.props.actions, data));
+    ipcRenderer.on('local-files-progress', (event, data) => onLocalFilesProgress(event, this.props.actions, data));
     ipcRenderer.on('local-files', (event, data) => onLocalFiles(event, this.props.actions, data));
     ipcRenderer.on('local-files-error', (event, err) => onLocalFilesError(event, this.props.actions, err));
 

--- a/packages/app/app/containers/LibraryViewContainer/index.js
+++ b/packages/app/app/containers/LibraryViewContainer/index.js
@@ -32,6 +32,8 @@ function mapStateToProps(state) {
 
   return {
     pending: state.local.pending,
+    scanProgress: state.local.scanProgress,
+    scanTotal: state.local.scanTotal,
     tracks: state.local.direction === 'ascending' ? tracks : tracks.reverse(),
       
     localFolders: state.local.folders,

--- a/packages/app/app/mpris.js
+++ b/packages/app/app/mpris.js
@@ -78,6 +78,10 @@ export function onUpdateEqualizer(event, actions, data) {
   actions.updateEqualizer(data);
 }
 
+export function onLocalFilesProgress(event, actions, {scanProgress, scanTotal}) {
+  actions.scanLocalFoldersProgress(scanProgress, scanTotal);
+}
+
 export function onLocalFiles(event, actions, data) {
   actions.scanLocalFoldersSuccess(data);
 }

--- a/packages/app/app/reducers/local.js
+++ b/packages/app/app/reducers/local.js
@@ -3,6 +3,7 @@ import {
   REMOVE_LOCAL_FOLDER,
   SCAN_LOCAL_FOLDER,
   SCAN_LOCAL_FOLDER_FAILED,
+  SCAN_LOCAL_FOLDER_PROGRESS,
   SCAN_LOCAL_FOLDER_SUCCESS,
   UPDATE_LOCAL_FILTER,
   UPDATE_LOCAL_SORT
@@ -51,16 +52,26 @@ export default function LocalReducer(state = initialState, action) {
       pending: true,
       error: false
     };
+  case SCAN_LOCAL_FOLDER_PROGRESS:
+    return {
+      ...state,
+      scanProgress: action.payload.scanProgress,
+      scanTotal: action.payload.scanTotal
+    };
   case SCAN_LOCAL_FOLDER_SUCCESS:
     return {
       ...state,
       pending: false,
+      scanProgress: null,
+      scanTotal: null,
       tracks: action.payload
     };
   case SCAN_LOCAL_FOLDER_FAILED:
     return {
       ...state,
       pending: false,
+      scanProgress: null,
+      scanTotal: null,
       error: true
     };
   case UPDATE_LOCAL_FILTER:

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -94,6 +94,7 @@
     "stream-reduce": "^1.0.3",
     "styled-components": "^3.2.6",
     "swagger-spec-express": "^2.0.15",
+    "tiny-async-pool": "^1.0.4",
     "uuid": "^3.3.2",
     "webpack-cli": "^3.0.8",
     "youtube-playlist": "^1.0.2",

--- a/packages/app/server/http/api/localfile.js
+++ b/packages/app/server/http/api/localfile.js
@@ -42,7 +42,10 @@ export function localFileRouter() {
 
   ipcMain.on('refresh-localfolders', async event => {
     try {
-      cache = await scanFoldersAndGetMeta(store.get('localFolders'), cache);
+      let onProgress = (scanProgress, scanTotal) => {
+        event.sender.send('local-files-progress', {scanProgress, scanTotal});
+      };
+      cache = await scanFoldersAndGetMeta(store.get('localFolders'), cache, onProgress);
 
       store.set('localMeta', cache);
       byArtist = _.groupBy(Object.values(cache), track => track.artist.name);

--- a/packages/app/server/lib/acousticId.js
+++ b/packages/app/server/lib/acousticId.js
@@ -15,7 +15,6 @@ export default async (filePath) => {
     fingerprint
   })}`);
 
-  const { results } = await res.json();
-
-  return results;
+  const output = await res.json();
+  return output;
 };


### PR DESCRIPTION
Changes:
* Greatly improved the speed of library scanning by having the scanning of tracks run in parallel. (currently set to 10 concurrent track-scans, as this is small enough it doesn't cause jitter when receiving child-process data)
* Added progress-bar for the library-scan operation. (progress bar to right of refresh button)
* Fixed that an error when fingerprinting a track (within `fpcalc`, when calling `fetchAcousticId`), would cause the entire library scan operation to fail.
* Fixed that exceeding the acoustic ID quota would cause a confusing "destructuring" error, instead of just logging the fetch-response error message.

Here's a screen-capture of the progress-bar being updated:
![](https://i.imgur.com/LLkcpkj.gif)