### PR TITLE
Fix that a filter (in Library view) with no matches breaks the UI

### DIFF
--- a/packages/app/app/components/LibraryView/NoSearchResults/index.js
+++ b/packages/app/app/components/LibraryView/NoSearchResults/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Icon } from 'semantic-ui-react';
+
+import styles from './styles.scss';
+
+export default () => {
+  const { t } = useTranslation('library');
+  return  (
+    <div className={styles.library_no_search_results}>
+      <Icon name='file audio outline' />
+      <h2>{ t('no-search-results')}</h2>
+      <div>{ t('no-search-results-help')}</div>
+    </div>
+  );
+};

--- a/packages/app/app/components/LibraryView/NoSearchResults/styles.scss
+++ b/packages/app/app/components/LibraryView/NoSearchResults/styles.scss
@@ -1,0 +1,6 @@
+@import '../../../mixin.scss';
+
+.library_no_search_results {
+  @include emptyState;
+  padding: 6rem 0;
+}

--- a/packages/app/app/components/LibraryView/index.js
+++ b/packages/app/app/components/LibraryView/index.js
@@ -21,9 +21,11 @@ import NoApi from './NoApi';
 
 import trackRowStyles from '../TrackRow/styles.scss';
 import styles from './index.scss';
+import NoSearchResults from './NoSearchResults';
 
 const LibraryView = ({
   tracks,
+  filterApplied,
   actions,
   pending,
   scanProgress,
@@ -90,21 +92,24 @@ const LibraryView = ({
       </Segment>
       <Segment>
         {api ? (
-          _.isEmpty(tracks) ? (
-            <EmptyState />
-          ) : (
-            <React.Fragment>
-              <div className={styles.search_field}>
-                <Input
-                  inverted
-                  transparent
-                  icon='search'
-                  iconPosition='left'
-                  placeholder={t('filter-placeholder')}
-                  onChange={actions.updateFilter}
-                />
-              </div>
-
+          <React.Fragment>
+            <div className={styles.search_field}>
+              <Input
+                inverted
+                transparent
+                icon='search'
+                iconPosition='left'
+                placeholder={t('filter-placeholder')}
+                onChange={actions.updateFilter}
+              />
+            </div>
+            {_.isEmpty(tracks) ? (
+              filterApplied ? (
+                <NoSearchResults />
+              ) : (
+                <EmptyState />
+              )
+            ) : (
               <Segment inverted className={trackRowStyles.tracks_container}>
                 <Dimmer active={pending} loading={pending.toString()} />
 
@@ -153,8 +158,8 @@ const LibraryView = ({
                   </Table>
                 )}
               </Segment>
-            </React.Fragment>
-          )
+            )}
+          </React.Fragment>
         ) : (
           <NoApi enableApi={actions.setBooleanOption} />
         )}
@@ -164,8 +169,11 @@ const LibraryView = ({
 };
 
 LibraryView.propTypes = {
-  pending: PropTypes.bool,
   tracks: PropTypes.array,
+  filterApplied: PropTypes.bool,
+  pending: PropTypes.bool,
+  scanProgress: PropTypes.number,
+  scanTotal: PropTypes.number,
   localFolders: PropTypes.arrayOf(PropTypes.string),
   // byArtist: PropTypes.object,
   actions: PropTypes.object,

--- a/packages/app/app/containers/LibraryViewContainer/index.js
+++ b/packages/app/app/containers/LibraryViewContainer/index.js
@@ -9,7 +9,8 @@ import * as SettingsActions from '../../actions/settings';
 function mapStateToProps(state) {
   const lowercaseFilter = _.lowerCase(state.local.filter);
   const checkFilter = string => _.includes(_.lowerCase(string), lowercaseFilter);
-  const filteredTracks = _.filter(_.values(state.local.tracks), track => {
+  const unfilteredTracks = _.values(state.local.tracks);
+  const filteredTracks = _.filter(unfilteredTracks, track => {
     return _.some([
       checkFilter(track.name),
       checkFilter(track.album),
@@ -31,10 +32,12 @@ function mapStateToProps(state) {
   }
 
   return {
+    tracks: state.local.direction === 'ascending' ? tracks : tracks.reverse(),
+    filterApplied: tracks.length < unfilteredTracks.length,
+
     pending: state.local.pending,
     scanProgress: state.local.scanProgress,
     scanTotal: state.local.scanTotal,
-    tracks: state.local.direction === 'ascending' ? tracks : tracks.reverse(),
       
     localFolders: state.local.folders,
     sortBy: state.local.sortBy,

--- a/packages/app/app/locales/en.json
+++ b/packages/app/app/locales/en.json
@@ -78,6 +78,8 @@
     "title": "Title",
     "empty": "The library is empty",
     "empty-help": "Try adding some music using the button above.",
+    "no-search-results": "No search results",
+    "no-search-results-help": "No tracks found with the given name, album, or artist.",
     "no-api": "Web API is not enabled",
     "no-api-help": "In order to use the local library you need to enable the web api.",
     "api-enable": "Enable the API"


### PR DESCRIPTION
Changes:
* Fixed that entering a filter text that doesn't match any tracks would hide the filter textbox, and show a "library empty" message (instead of a "no search results" message)
* Added some missing entries to LibraryView.PropTypes.