### PR TITLE
Replace 'link above' text with mps-youtube URL

### DIFF
--- a/docs/electron.md
+++ b/docs/electron.md
@@ -1,6 +1,6 @@
 ## What if I am religiously opposed to using Electron for any and all purposes?
 
-Then you are not the target audience of this program. See mps-youtube (link above) for a similar program that will not taint your machine with a library you happen to dislike.
+Then you are not the target audience of this program. See [mps-youtube](https://github.com/mps-youtube/mps-youtube) for a similar program that will not taint your machine with a library you happen to dislike.
 
 On an unrelated note, highly polarized opinions about languages and frameworks are characteristic of people who lack real-world programming experience and are more interested in building an identity than creating computer programs.
 


### PR DESCRIPTION
Since this note moved to its own file, I think this 'link above' was missed out on. So fixed that.