### PR TITLE
Change playlist actions to mimic album view 

### DIFF
--- a/packages/app/app/components/AlbumView/index.js
+++ b/packages/app/app/components/AlbumView/index.js
@@ -6,6 +6,7 @@ import { withTranslation } from 'react-i18next';
 import _ from 'lodash';
 
 import ContextPopup from '../ContextPopup';
+import PopupButton from '../ContextPopup/PopupButton';
 import TrackRow from '../TrackRow';
 import * as Utils from '../../utils';
 import {safeAddUuid} from '../../actions/helpers';
@@ -264,19 +265,21 @@ class AlbumView extends React.Component {
         title={album.title}
         thumb={this.getAlbumImage(album)}
       >
-        <a
-          href='#'
-          onClick={() => this.addAlbumToQueue(album)}
-          aria-label={this.props.t('queue')}
-        >
-          <Icon name='plus' /> {this.props.t('queue')}
-        </a>
-        <a
-          href='#'
-          onClick={() => this.addAlbumToDownloads(album)}
-        >
-          <Icon name='download'/> {this.props.t('download')}
-        </a>
+        <PopupButton 
+          onClick={() => 
+            this.addAlbumToQueue(album)
+          }
+          ariaLabel={this.props.t('queue')}
+          icon='plus'
+          label={this.props.t('queue')}
+        />
+        <PopupButton 
+          onClick={() =>
+          this.addAlbumToDownloads(album)}
+          ariaLabel={this.props.t('download')}
+          icon='download'
+          label={this.props.t('download')}
+        />
       </ContextPopup>
     );
   }

--- a/packages/app/app/components/PlaylistView/index.js
+++ b/packages/app/app/components/PlaylistView/index.js
@@ -20,16 +20,11 @@ class PlaylistView extends React.Component {
     super(props);
   }
 
-  addPlaylistToQueue (
-    streamProviders,
-    playlist,
-    addTracks,
-    selectSong,
-    startPlayback
-  ) {
-    addTracks(streamProviders, playlist.tracks);
-    selectSong(0);
-    startPlayback();
+  playAll (playlist, streamProviders) {
+    this.props.clearQueue();
+    this.props.addTracks(streamProviders, playlist.tracks);
+    this.props.selectSong(0);
+    this.props.startPlayback();
   }
 
   deletePlaylist(playlist) {
@@ -48,7 +43,11 @@ class PlaylistView extends React.Component {
     this.props.updatePlaylist(updatedPlaylist);
   }
 
-  renderOptions (trigger, playlist) {
+  renderOptions (
+    trigger, 
+    playlist,
+    streamProviders,
+    ) {
     return (
       <ContextPopup
         trigger={trigger}
@@ -64,6 +63,14 @@ class PlaylistView extends React.Component {
           icon='trash'
           label={this.props.t('delete')}
         />
+        <PopupButton 
+          onClick={() => 
+            this.props.addTracks(streamProviders, playlist.tracks)
+          }
+          ariaLabel={this.props.t('queue')}
+          icon='plus'
+          label={this.props.t('queue')}
+        />
       </ContextPopup>
     );
   }
@@ -71,10 +78,7 @@ class PlaylistView extends React.Component {
   renderPlayButton () {
     const {
       playlist,
-      addTracks,
       streamProviders,
-      selectSong,
-      startPlayback
     } = this.props;
 
     return (
@@ -82,13 +86,7 @@ class PlaylistView extends React.Component {
         href='#'
         className={styles.play_button}
         onClick={() =>
-          this.addPlaylistToQueue(
-            streamProviders,
-            playlist,
-            addTracks,
-            selectSong,
-            startPlayback
-          )
+          this.playAll(playlist, streamProviders)
         }
       >
         <Icon name='play' /> Play
@@ -97,7 +95,10 @@ class PlaylistView extends React.Component {
   }
 
   renderPlaylistInfo () {
-    let { playlist } = this.props;
+    let { 
+      playlist,
+      streamProviders,
+     } = this.props;
     let popupTrigger = (
       <a href='#' className={styles.more_button}>
         <Icon name='ellipsis horizontal' />
@@ -135,7 +136,12 @@ class PlaylistView extends React.Component {
           </div>
           <div className={styles.playlist_buttons}>
             { this.renderPlayButton() }
-            { this.renderOptions(popupTrigger, playlist) }
+            { this.renderOptions(
+                popupTrigger,
+                playlist,
+                streamProviders,
+                ) 
+              }
           </div>
         </div>
       </div>

--- a/packages/app/app/components/PlaylistView/index.js
+++ b/packages/app/app/components/PlaylistView/index.js
@@ -20,9 +20,9 @@ class PlaylistView extends React.Component {
     super(props);
   }
 
-  playAll (playlist, streamProviders) {
+  playAll (playlist) {
     this.props.clearQueue();
-    this.props.addTracks(streamProviders, playlist.tracks);
+    this.props.addTracks(this.props.streamProviders, playlist.tracks);
     this.props.selectSong(0);
     this.props.startPlayback();
   }
@@ -46,7 +46,6 @@ class PlaylistView extends React.Component {
   renderOptions (
     trigger, 
     playlist,
-    streamProviders,
     ) {
     return (
       <ContextPopup
@@ -55,6 +54,14 @@ class PlaylistView extends React.Component {
         title={playlist.name}
         thumb={_.get(playlist, 'tracks[0].thumbnail', artPlaceholder)}
       >
+        <PopupButton 
+          onClick={() => 
+            this.props.addTracks(this.props.streamProviders, playlist.tracks)
+          }
+          ariaLabel={this.props.t('queue')}
+          icon='plus'
+          label={this.props.t('queue')}
+        />
         <PopupButton
           onClick={() =>
             this.deletePlaylist(this.props.playlist)
@@ -63,30 +70,18 @@ class PlaylistView extends React.Component {
           icon='trash'
           label={this.props.t('delete')}
         />
-        <PopupButton 
-          onClick={() => 
-            this.props.addTracks(streamProviders, playlist.tracks)
-          }
-          ariaLabel={this.props.t('queue')}
-          icon='plus'
-          label={this.props.t('queue')}
-        />
       </ContextPopup>
     );
   }
 
-  renderPlayButton () {
-    const {
-      playlist,
-      streamProviders,
-    } = this.props;
+  renderPlayButton (playlist) {
 
     return (
       <a
         href='#'
         className={styles.play_button}
         onClick={() =>
-          this.playAll(playlist, streamProviders)
+          this.playAll(playlist, this.props.streamProviders)
         }
       >
         <Icon name='play' /> Play
@@ -94,11 +89,7 @@ class PlaylistView extends React.Component {
     );
   }
 
-  renderPlaylistInfo () {
-    let { 
-      playlist,
-      streamProviders,
-     } = this.props;
+  renderPlaylistInfo (playlist) {
     let popupTrigger = (
       <a href='#' className={styles.more_button}>
         <Icon name='ellipsis horizontal' />
@@ -135,11 +126,10 @@ class PlaylistView extends React.Component {
             />
           </div>
           <div className={styles.playlist_buttons}>
-            { this.renderPlayButton() }
+            { this.renderPlayButton(playlist) }
             { this.renderOptions(
                 popupTrigger,
                 playlist,
-                streamProviders,
                 ) 
               }
           </div>
@@ -181,7 +171,7 @@ class PlaylistView extends React.Component {
     return (
       <div className={styles.playlist_view_container}>
         <div className={styles.playlist}>
-          {this.renderPlaylistInfo()}
+          {this.renderPlaylistInfo(playlist)}
           <div className={styles.playlist_tracks}>
             <table>
               {this.renderPlaylistTracksHeader()}

--- a/packages/app/app/containers/PlaylistViewContainer/index.js
+++ b/packages/app/app/containers/PlaylistViewContainer/index.js
@@ -19,6 +19,7 @@ const PlaylistViewContainer = props => {
       selectSong={props.actions.selectSong}
       startPlayback={props.actions.startPlayback}
       addToQueue={props.actions.addToQueue}
+      clearQueue={props.actions.clearQueue}
       deletePlaylist={props.actions.deletePlaylist}
       updatePlaylist={props.actions.updatePlaylist}
       history={props.history}

--- a/packages/app/app/locales/en.json
+++ b/packages/app/app/locales/en.json
@@ -103,6 +103,7 @@
   "playlists": {
     "artist": "Artist",
     "delete": "Delete this playlist",
+    "queue": "Add playlist to queue",
     "dialog-placeholder": "Playlist name...",
     "empty": "No playlists.",
     "rename": "Rename this playlist",


### PR DESCRIPTION
resolves #530 
-added option for a playlist to be added to the end of a queue under the '...' options menu

the translations are now missing an "add playlist to end of queue" line for playlists. 
"add album to end of queue" and "playlist" translations do exist though.
Should I possibly butcher some languages and assume I can just replace "album" with "playlist" in each corresponding language translation as a temporary solution?