### PR TITLE
Album cover maintains img aspect ratio

### DIFF
--- a/packages/app/app/components/ContextPopup/styles.scss
+++ b/packages/app/app/components/ContextPopup/styles.scss
@@ -36,6 +36,7 @@
   flex: 0 0 auto;
   width: 5rem;
   height: 5rem;
+  object-fit: contain;
 
   img {
     width: 5rem;

--- a/packages/app/app/components/TrackRow/styles.scss
+++ b/packages/app/app/components/TrackRow/styles.scss
@@ -55,7 +55,7 @@
   &:hover {
     background: rgba($background2, 0.25);
   }
-  
+
   &:last-child {
     td {
       border-bottom: none;
@@ -82,6 +82,7 @@
     width: 3em;
     height: 3em;
     display: block;
+    object-fit: contain;
   }
 }
 


### PR DESCRIPTION
Related to #526 

This ensures that album cover maintains the image aspect ratio:

![image](https://user-images.githubusercontent.com/6725396/67160865-9b1cc800-f387-11e9-87c1-5000e0eb90c0.png)
