### PR TITLE
Adding virtualization to the local-library track-rows

### DIFF
--- a/packages/app/app/components/LibraryView/index.js
+++ b/packages/app/app/components/LibraryView/index.js
@@ -9,10 +9,12 @@ import {
   List,
   Progress,
   Segment,
-  Table
+  Table,
+  Ref
 } from 'semantic-ui-react';
 import { useTranslation } from 'react-i18next';
 import _ from 'lodash';
+import ReactList from 'react-list';
 
 import Header from '../Header';
 import TrackRow from '../TrackRow';
@@ -114,48 +116,60 @@ const LibraryView = ({
                 <Dimmer active={pending} loading={pending.toString()} />
 
                 {!pending && (
-                  <Table sortable className={styles.table}>
-                    <Table.Header className={styles.thead}>
-                      <Table.Row>
-                        <Table.HeaderCell>
-                          <Icon name='image' />
-                        </Table.HeaderCell>
-                        <Table.HeaderCell
-                          sorted={sortBy === 'artist' ? direction : null}
-                          onClick={handleSort('artist')}
-                        >
-                          {t('artist')}
-                        </Table.HeaderCell>
-                        <Table.HeaderCell
-                          sorted={sortBy === 'name' ? direction : null}
-                          onClick={handleSort('name')}
-                        >
-                          {t('title')}
-                        </Table.HeaderCell>
-                        <Table.HeaderCell
-                          sorted={sortBy === 'album' ? direction : null}
-                          onClick={handleSort('album')}
-                        >
-                          {t('album')}
-                        </Table.HeaderCell>
-                      </Table.Row>
-                    </Table.Header>
-                    <Table.Body className={styles.tbody}>
-                      {tracks &&
-                        tracks.map((track, idx) => (
-                          <TrackRow
-                            key={'favorite-track-' + idx}
-                            track={track}
-                            index={idx}
-                            displayCover
-                            displayArtist
-                            displayAlbum
-                            withAddToDownloads={false}
-                            isLocal
-                          />
-                        ))}
-                    </Table.Body>
-                  </Table>
+                  <ReactList
+                    type='uniform'
+                    length={tracks.length}
+                    itemsRenderer={(items, ref) => {
+                      return (
+                        <Table sortable className={styles.table}>
+                          <Table.Header className={styles.thead}>
+                            <Table.Row>
+                              <Table.HeaderCell>
+                                <Icon name='image' />
+                              </Table.HeaderCell>
+                              <Table.HeaderCell
+                                sorted={sortBy === 'artist' ? direction : null}
+                                onClick={handleSort('artist')}
+                              >
+                                {t('artist')}
+                              </Table.HeaderCell>
+                              <Table.HeaderCell
+                                sorted={sortBy === 'name' ? direction : null}
+                                onClick={handleSort('name')}
+                              >
+                                {t('title')}
+                              </Table.HeaderCell>
+                              <Table.HeaderCell
+                                sorted={sortBy === 'album' ? direction : null}
+                                onClick={handleSort('album')}
+                              >
+                                {t('album')}
+                              </Table.HeaderCell>
+                            </Table.Row>
+                          </Table.Header>
+                          <Ref innerRef={ref}>
+                            <Table.Body className={styles.tbody}>
+                              {items}
+                            </Table.Body>
+                          </Ref>
+                        </Table>
+                      );
+                    }}
+                    itemRenderer={index => {
+                      const track = tracks[index];
+                      return (
+                        <TrackRow
+                          key={'favorite-track-' + index}
+                          track={track}
+                          index={index}
+                          displayCover
+                          displayArtist
+                          displayAlbum
+                          withAddToDownloads={false}
+                          isLocal
+                        />
+                      );
+                    }}/>
                 )}
               </Segment>
             )}

--- a/packages/app/app/components/LibraryView/index.js
+++ b/packages/app/app/components/LibraryView/index.js
@@ -117,8 +117,9 @@ const LibraryView = ({
 
                 {!pending && (
                   <ReactList
-                    type='uniform'
+                    type='variable'
                     length={tracks.length}
+                    itemSizeEstimator={() => 44}
                     itemsRenderer={(items, ref) => {
                       return (
                         <Table sortable className={styles.table}>

--- a/packages/app/app/components/LibraryView/index.scss
+++ b/packages/app/app/components/LibraryView/index.scss
@@ -43,6 +43,8 @@
 
   .tracks_container {
     margin-top: 0;
+    // fix for react-list excluding header from its height-calc
+    div:nth-child(2) { margin-bottom: 58px; }
   }
   
   .table {
@@ -57,6 +59,11 @@
       background: transparent !important;
       border-bottom: 0.5px solid rgba(250, 250, 250, 0.5) !important;
     }
+    // since virtualization is used, we have to pre-define the column widths
+    // (the width of the third column, title, is whatever is left over)
+    th:nth-child(1) { width: 42px; }
+    th:nth-child(2) { width: 30%; }
+    th:nth-child(4) { width: 25%; }
   }
 
   .tbody {

--- a/packages/app/app/components/TrackRow/index.js
+++ b/packages/app/app/components/TrackRow/index.js
@@ -54,7 +54,7 @@ class TrackRow extends React.Component {
 
   canAddToFavorites() {
     return _.findIndex(this.props.favoriteTracks, (currentTrack) => {
-      return currentTrack.name === this.props.track.name && currentTrack.artist.name === this.props.track.artist.name
+      return currentTrack.name === this.props.track.name && currentTrack.artist.name === this.props.track.artist.name;
     }) < 0;
   }
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "@nuclear/core": "0.5.1",
     "@nuclear/ui": "0.5.1",
-    "music-metadata": "^3.5.3",
     "billboard-top-100": "^2.0.8",
     "bluebird": "3.5.3",
     "body-parser": "^1.18.3",
@@ -73,6 +72,7 @@
     "md5": "^2.2.1",
     "moment": "^2.20.1",
     "mousetrap": "^1.6.2",
+    "music-metadata": "^3.5.3",
     "numeral": "^2.0.6",
     "pitchfork-bnm": "^1.0.3",
     "react": "^16.8.6",
@@ -82,6 +82,7 @@
     "react-i18next": "^10.11.0",
     "react-image": "^2.1.1",
     "react-image-smooth-loading": "^2.0.0",
+    "react-list": "^0.8.13",
     "react-range-progress": "^4.0.3",
     "react-redux": "^7.1.0",
     "react-toastify": "^4.5.2",

--- a/packages/app/server/main.dev.js
+++ b/packages/app/server/main.dev.js
@@ -71,9 +71,10 @@ function createWindow() {
 
   win.once('ready-to-show', () => {
     win.show();
+    // this must run after win.show(), otherwise startup errors cause
+    // dev-tools to pause execution, causing "ready-to-show" to never trigger
+    win.webContents.openDevTools();
   });
-
-  win.webContents.openDevTools();
 
   win.on('closed', () => {
     win = null;


### PR DESCRIPTION
* Fixed that, in development, program would fail to launch if an error occurred during startup. (resolves #545)
* Added virtualization of the track-rows in LibraryView. This dramatically improves performance for large local libraries, and solves the extreme jittering/freezing that occurs when attempting to play a song while having the library page open.

Here's a video of the virtualized, much-smoother library UI in action (previously it would jitter/freeze so much during song playback that pressing a button would have multi-second delays):
![](https://i.imgur.com/cesLKD7.gif)

This resolves the performance issue mentioned in #331. (though I still recommend being cautious about placing frequently-updating state in the Redux store, the overall UI responsiveness is acceptable now)