### PR TITLE
Fix album height on artist page

### DIFF
--- a/packages/app/app/components/AlbumList/styles.scss
+++ b/packages/app/app/components/AlbumList/styles.scss
@@ -1,7 +1,6 @@
 .album_list_container {
   display: flex;
   width: 100%;
-  height: 100%;
 }
 
 .album_list_cards {


### PR DESCRIPTION
The height of the album on a artist page was too high if there were juste some albums. 

| Before | <img  width="450" src="https://user-images.githubusercontent.com/35188982/68541226-2264c680-039d-11ea-9b67-bdf2dee68830.png" /> |
| --- | --- |
| After | <img width="450" src="https://user-images.githubusercontent.com/35188982/68541234-2c86c500-039d-11ea-8518-33d5ef274279.png" /> |

