### PR TITLE
Fix testing with other nuclear packages

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,7 +14,7 @@
     "build:electron:linux": "webpack --progress --colors --env.LINUX=true --config=webpack.config.electron.prod.js",
     "build:electron": "webpack --progress --colors --config=webpack.config.electron.prod.js",
     "build:docker": "docker build -t nuclear .",
-    "test": "mocha --require ./test/testHelper.js --require @babel/register --require regenerator-runtime --timeout 10000 --prof --recursive",
+    "test": "mocha --require ./test/testHelper.js --require regenerator-runtime --timeout 10000 --prof --recursive",
     "pack": "electron-builder --dir -c.extraMetadata.main=dist/bundle.electron.js",
     "dist": "babel-node electron-builder -c.extraMetadata.main=dist/bundle.electron.js",
     "build:linux": "electron-builder -c.extraMetadata.main=dist/bundle.electron.js --linux --publish always",

--- a/packages/app/test/testHelper.js
+++ b/packages/app/test/testHelper.js
@@ -6,3 +6,7 @@ register(undefined, (module, filename) => {
     module.exports = 'IMAGE_MOCK';
   }
 });
+
+require("@babel/register")({
+  ignore: [/node_modules/]
+});


### PR DESCRIPTION
There's an issue when trying to create integration or just general tests in `nuclear/app` and I want to use components from `@nuclear/ui`. 

ex. `example-test.js`
```
import React from 'react';
import chai from 'chai';
import spies from 'chai-spies';
import { shallow } from 'enzyme';
import { describe, it } from 'mocha';

import QueueMenuMore from '../app/components/PlayQueue/QueueMenu/QueueMenuMore';
import {QueueItem} from '@nuclear/ui' //<-- OFFENDING LINE
```

Currently, it won't work because babel isn't properly compiling those package files. 

<img width="1318" alt="Screen Shot 2019-11-12 at 12 31 08 AM" src="https://user-images.githubusercontent.com/8953212/68645022-cc9b3600-04e4-11ea-9e7d-d328be5381db.png">

After looking it up, it seems to be an issue with `node_modules` not being ignored, but I see we're doing that in our `babel.config.js` file. Anyways, after looking at https://github.com/babel/babel/issues/9511, I added babel/register to our testHelper instead of our `--require @babel/register` through npm scripts. Now it works as expected, which will allow us to import components from existing nuclear packages in the monorepo.

