### PR TITLE
Fix crash & album display

### DIFF
--- a/packages/main/src/controllers/local-library.ts
+++ b/packages/main/src/controllers/local-library.ts
@@ -11,7 +11,7 @@ class LocalIpcCtrl {
     @inject(LocalLibrary) private localLibrary: LocalLibrary,
     @inject(LocalLibraryDb) private localLibraryDb: LocalLibraryDb
   ) {}
-  
+
   /**
    * get local libray folder from store
    */
@@ -21,7 +21,7 @@ class LocalIpcCtrl {
   }
 
   /**
-   * store local library folders 
+   * store local library folders
    */
   @ipcEvent('set-localfolders')
   setLocalFolders(event: IpcMessageEvent, localFolders: string[]) {
@@ -33,11 +33,11 @@ class LocalIpcCtrl {
    */
   @ipcEvent('refresh-localfolders')
   async onRefreshLocalFolders(event: IpcMessageEvent) {
-    try {      
+    try {
       const cache = await this.localLibrary.scanFoldersAndGetMeta((scanProgress, scanTotal) => {
         event.sender.send('local-files-progress', {scanProgress, scanTotal});
       });
-  
+
       event.sender.send('local-files', cache);
     } catch (err) {
       event.sender.send('local-files-error', err);

--- a/packages/main/src/services/local-library/db.ts
+++ b/packages/main/src/services/local-library/db.ts
@@ -26,7 +26,7 @@ class LocalLibraryDb extends ElectronStore {
   byArtist(): Record<string, NuclearBrutMeta[]> {
     const cache: LocalMeta = this.get('localMeta');
 
-    return _.groupBy(Object.values(cache), track => track.artist.name);
+    return cache ? _.groupBy(Object.values(cache), track => track.artist.name) : {};
   }
 
   search({ artist, track }: LocalSearchQuery) {
@@ -50,7 +50,7 @@ class LocalLibraryDb extends ElectronStore {
         thumbnail: track.image && track.image[0] ? track.image[0]['#text'] : undefined
       }))
       .pop();
-    
+
     return result;
   }
 

--- a/packages/ui/lib/components/Range/index.scss
+++ b/packages/ui/lib/components/Range/index.scss
@@ -41,7 +41,6 @@
 
 .track {
   border: 0;
-  position: absolute;
   width: 100%;
 }
 


### PR DESCRIPTION
Album display:

| Before | <img src="https://user-images.githubusercontent.com/35188982/71354945-c4bbc080-257d-11ea-8f89-ee7ebcb79239.png"> |
| - | - |
| **After** | <img src="https://user-images.githubusercontent.com/35188982/71354985-e2892580-257d-11ea-8250-e19d4fe57fa1.png"> |


App crash:

When trying to add a track to the queue, the function "search" is run on the local-library. This function call "byArtist", which get all the local track and try to find the wanted one. But if there is no local track, the function "byArtist" return null and make the app crash. A simple ternary operator returning an empty object fix that.
