### PR TITLE
fix(trackrow): check empty string and apply placeholder

### DIFF
--- a/packages/app/app/components/TrackRow/index.js
+++ b/packages/app/app/components/TrackRow/index.js
@@ -45,11 +45,13 @@ class TrackRow extends React.Component {
   }
 
   getTrackThumbnail() {
-    return _.get(
+    const thumb = _.get(
       this.props.track,
       'thumbnail',
       _.get(this.props.track, 'image[0][#text]', artPlaceholder)
     );
+
+    return thumb === '' ? artPlaceholder : thumb;
   }
 
   canAddToFavorites() {


### PR DESCRIPTION
sometimes in the search, trackrow thumbnail was in 404, it was because the metadata sometimes contain empty string for thumbnail.