### PR TITLE
Fix AlbumGrid and AlbumPreview for local library

### DIFF
--- a/packages/ui/lib/utils.js
+++ b/packages/ui/lib/utils.js
@@ -28,9 +28,14 @@ export function formatDuration(duration) {
 }
 
 export const getThumbnail = album => {
-  return _.get(album, 'images[0].uri',
+  
+  let thumbnail = _.get(album, 'images[0].uri',
     _.get(album, 'image[0][\'#text\']',
       _.get(album, 'thumb')));
+
+  let isLocalThumbnail = Array.isArray(thumbnail);
+  
+  return isLocalThumbnail ? thumbnail[0].replace(/\\/g, '/') : thumbnail;
 };
 
 export const getTrackItem = track => ({


### PR DESCRIPTION
The AlbumGrid and AlbumPreview components in the local library were expecting the path to an image file but received an array containing the path instead. This commit fixes that by grabbing the first item in the array while also replacing any backslashes as those broke the path on Windows.
Thumbnails should now properly load again.

This fix was tested on Windows 10 1909 and a Manjaro 18.1.4 VM.

~EDIT: Don't merge this yet as it breaks albums for the online search. Will check for a solution.~

EDIT2: All tests pass locally now and Nuclear behaves as expected again. Should be fine to merge.