### PR TITLE
Change Discord Rich Presence Details Text

### DIFF
--- a/packages/main/src/services/discord/index.ts
+++ b/packages/main/src/services/discord/index.ts
@@ -19,7 +19,7 @@ class Discord {
   private async sendActivity(track: NuclearMeta) {
     try {
       await this.rpc.setActivity({
-        details: `listening to ${track.artist} ${track.name}`,
+        details: `${track.artist} - ${track.name}`,
         startTimestamp: Date.now(),
         largeImageKey: 'logo'
       });


### PR DESCRIPTION
Before, the details text said "listening to" which took up half the space, so you would get part of the artist's name and the rest would be cut off.

**New behaviour**:
![image](https://user-images.githubusercontent.com/14253836/74885217-a0d8e900-533a-11ea-84b4-cb480750de06.png)

Also, added a `-` to separate the artist and title
