### PR TITLE
updated development process instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ Use lerna:
 ```shell
 $ npm i -g lerna #installs lerna globally
 $ lerna bootstrap
+$ cd packages/app/
+$ npm start
+```
+This will start the server. Wait for webpack to finish compiling. Then in a second terminal, 
+
+```shell
+$ cd packages/main/ 
 $ npm start
 ```
 


### PR DESCRIPTION
The development process instructions in the readme don't work. I get this error: 

```lerna notice cli v3.20.2
lerna info Executing command in 4 packages: "npm run start"
@nuclear/core: > @nuclear/core@0.6.3 start C:\Users\harsh\web\nuclear\packages\core
@nuclear/core: > tsc
@nuclear/i18n: > @nuclear/i18n@0.6.3 start C:\Users\harsh\web\nuclear\packages\i18n
@nuclear/i18n: > tsc
@nuclear/core: src/interfaces/index.ts(1,21): error TS2307: Cannot find module 'electron'.
@nuclear/core: src/settings/index.ts(1,29): error TS2307: Cannot find module 'electron'.
@nuclear/core: npm ERR! code ELIFECYCLE
@nuclear/core: npm ERR! errno 2
@nuclear/core: npm ERR! @nuclear/core@0.6.3 start: `tsc`
@nuclear/core: npm ERR! Exit status 2
@nuclear/core: npm ERR!
@nuclear/core: npm ERR! Failed at the @nuclear/core@0.6.3 start script.
@nuclear/core: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
@nuclear/core: npm ERR! A complete log of this run can be found in:
@nuclear/core: npm ERR!     C:\Users\harsh\AppData\Roaming\npm-cache\_logs\2020-03-12T11_41_18_102Z-debug.log
lerna ERR! npm run start exited 2 in '@nuclear/core'
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! nuclear@0.6.3 start: `lerna run start --stream`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the nuclear@0.6.3 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\harsh\AppData\Roaming\npm-cache\_logs\2020-03-12T11_41_18_557Z-debug.log
```


