### PR TITLE
Fix local tracks in playlists

### DIFF
--- a/packages/app/app/components/TrackRow/index.js
+++ b/packages/app/app/components/TrackRow/index.js
@@ -40,7 +40,9 @@ class TrackRow extends React.Component {
     this.props.actions.playTrack(this.props.streamProviders, {
       artist: this.props.track.artist.name,
       name: this.props.track.name,
-      thumbnail: this.getTrackThumbnail()
+      thumbnail: this.getTrackThumbnail(),
+	  local: this.props.track.local,
+	  streams: this.props.track.streams
     });
   }
 

--- a/packages/app/app/containers/TrackPopupContainer/index.js
+++ b/packages/app/app/containers/TrackPopupContainer/index.js
@@ -32,7 +32,9 @@ const TrackPopupContainer = props => {
   const trackItem = {
     artist,
     name: title,
-    thumbnail: props.thumb
+    thumbnail: props.thumb,
+    local: track.local,
+    streams: track.streams
   };
 
   return (


### PR DESCRIPTION
These commits fix #655.
Playlists will now pass on the `streams` and `local` key of tracks so local tracks can be played again. I don't believe passing either of those keys on will cause any issues with remote tracks. I have tested with multiple songs from Invidious and a really old data sample from YouTube and haven't encountered any issues so far.