### PR TITLE
Fix PlaylistView and stringDurationToSeconds()

### DIFF
--- a/packages/app/app/components/PlaylistView/index.js
+++ b/packages/app/app/components/PlaylistView/index.js
@@ -100,7 +100,7 @@ class PlaylistView extends React.Component {
         <div>
           <img
             className={styles.playlist_thumbnail}
-            src={_.get(playlist, 'tracks[0].thumbnail', '')}
+            src={_.get(playlist, 'tracks[0].thumbnail', artPlaceholder)}
           />
         </div>
         <div className={styles.playlist_header}>

--- a/packages/app/app/utils.js
+++ b/packages/app/app/utils.js
@@ -29,7 +29,7 @@ export function stringDurationToSeconds(duration) {
     if (parts.length === 2) {
       parts.unshift(0);
     }
-    return parseInt(parts[0]) * 3600 + parseInt(parts[1]) * 60 + parseInt(parts[1]);
+    return parseInt(parts[0]) * 3600 + parseInt(parts[1]) * 60 + parseInt(parts[2]);
   }
   return 0;
 }


### PR DESCRIPTION
These commits fix multiple bugs I encountered.
First, in the PlaylistView if no thumbnail existed for a song no artwork would be rendered making it look very bad. This was fixed by simply using the existing `artPlaceholder` in case no thumbnail is found.
Second, the `stringDurationToSeconds` function returned results like 3:03, 4:04, 5:05, 6:06, etc in the AlbumView when looking at albums of an artist. This was caused due to a wrong array index being used.