### PR TITLE
Fixed build script not running on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "postinstall": "lerna bootstrap --no-ci",
     "start": "lerna run start --stream",
-    "build": "rm -rf dist && lerna run build && npm run pack",
+    "build": "shx rm -rf dist && lerna run build && npm run pack",
     "test": "lerna run build && lerna run test",
     "lint": "lerna run lint",
     "storybook": "lerna run storybook",
@@ -47,6 +47,7 @@
     "husky": "^3.1.0",
     "lerna": "^3.16.4",
     "lint-staged": "^10.0.0-beta.14",
+    "shx": "^0.3.2",
     "typescript": "^3.7.4"
   },
   "optionalDependencies": {

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.3",
   "description": "Nuclear main process",
   "scripts": {
-    "start": "rm -rf build && webpack --env.NODE_ENV=development && electron build/main.js",
+    "start": "shx rm -rf build && webpack --env.NODE_ENV=development && electron build/main.js",
     "build": "webpack --colors --env.NODE_ENV=production",
     "lint": "eslint src/**/*.ts --fix"
   },


### PR DESCRIPTION
* Fixed build script not running on Windows, by using the cross-platform "shx" equivalent. (resolves #683)