### PR TITLE
Uncomment app.quit()

### DIFF
--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -87,7 +87,7 @@ app.on('window-all-closed', async () => {
       await httpApi.close();
     }
 
-    // app.quit();
+    app.quit();
   } catch (err) {
     logger.error('something fail during app close');
     logger.error(err);


### PR DESCRIPTION
Should allow the app the terminate properly now instead of lingering in the background.