### PR TITLE
Saves volume upon restart

### DIFF
--- a/packages/app/app/actions/player.js
+++ b/packages/app/app/actions/player.js
@@ -1,5 +1,6 @@
 import Sound from 'react-hifi';
 import { mpris } from '@nuclear/core';
+import { setOption } from '@nuclear/core';
 
 export const START_PLAYBACK = 'START_PLAYBACK';
 export const PAUSE_PLAYBACK = 'PAUSE_PLAYBACK';
@@ -62,6 +63,7 @@ export function updateSeek(seek) {
 }
 
 export function updateVolume(volume) {
+  setOption('volume', volume);
   mpris.sendVolume(volume);
   return {
     type: UPDATE_VOLUME,

--- a/packages/app/app/reducers/player.js
+++ b/packages/app/app/reducers/player.js
@@ -1,4 +1,5 @@
 import Sound from 'react-hifi';
+import { getOption } from '@nuclear/core';
 
 import {
   START_PLAYBACK,
@@ -22,7 +23,7 @@ const initialState = {
   playbackStreamLoading: false,
   playbackProgress: 0,
   seek: 0,
-  volume: 100,
+  volume: getOption('volume'),
   muted: false
 };
 

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -34,6 +34,14 @@ type Setting = {
 
 export const settingsConfig: Array<Setting> = [
   {
+    name: 'volume',
+    category: 'audio',
+    description: 'volume-description',
+    type: SettingType.NUMBER,
+    prettyName: 'volume',
+    default: 50
+  },
+  {
     name: 'loopAfterQueueEnd',
     category: 'playback',
     type: SettingType.BOOLEAN,


### PR DESCRIPTION
This is a pull request that would resolve https://github.com/nukeop/nuclear/issues/679
I’ve made the following changes https://github.com/nukeop/nuclear/pull/700/files:
- Defined a new setting for volume
- Updates the setting every time volume is updated
- Sets initial volume state to previously saved volume