### PR TITLE
Fixed conditional to handle after song has been played

### DIFF
--- a/packages/app/app/containers/SoundContainer/index.js
+++ b/packages/app/app/containers/SoundContainer/index.js
@@ -82,7 +82,7 @@ class SoundContainer extends React.Component {
     }
 
     if (
-      this.props.queue.currentSong < this.props.queue.queueItems.length - 1 ||
+      this.props.queue.queueItems.length !== 0 ||
       this.props.settings.loopAfterQueueEnd
     ) {
       this.props.actions.nextSong();

--- a/packages/app/app/containers/SoundContainer/index.js
+++ b/packages/app/app/containers/SoundContainer/index.js
@@ -82,7 +82,8 @@ class SoundContainer extends React.Component {
     }
 
     if (
-      this.props.queue.queueItems.length !== 0 ||
+      this.props.settings.shuffleQueue ||
+      this.props.queue.currentSong < this.props.queue.queueItems.length - 1 ||
       this.props.settings.loopAfterQueueEnd
     ) {
       this.props.actions.nextSong();


### PR DESCRIPTION
I've changed the second conditional in handleFinishedPlaying to continue to select songs as long as the queue is not empty, rather than until the last song in the queue is selected. This fixes the issue mentioned in https://github.com/nukeop/nuclear/issues/677, however if shuffle is toggled and the song that is selected randomly is the one that just played, playback is paused. I believe this is related to the issue mentioned in https://github.com/nukeop/nuclear/issues/475. 