### PR TITLE
fix(soundcloudPlugin.ts): transform ms to seconds

### DIFF
--- a/packages/core/src/plugins/stream/SoundcloudPlugin.ts
+++ b/packages/core/src/plugins/stream/SoundcloudPlugin.ts
@@ -14,12 +14,12 @@ class SoundcloudPlugin extends StreamProviderPlugin {
     this.image = null;
   }
 
-  resultToStream(result) {
+  resultToStream(result): StreamData {
     return {
       source: this.sourceName,
       id: result.id,
       stream: result.stream_url + `?client_id=${process.env.SOUNDCLOUD_API_KEY}`,
-      duration: result.duration,
+      duration: result.duration/1000,
       title: result.title,
       thumbnail: result.user.avatar_url
     };


### PR DESCRIPTION
Soundcloud's [API](https://developers.soundcloud.com/docs/api/reference#tracks) returns duration in milliseconds, but the field in StreamData expects seconds.