### PR TITLE
Fix genre images out of sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
      - GITHASH=${TRAVIS_COMMIT::6}
 
 before_install:
-  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install libdbus-1-dev -y; fi
+  - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install libdbus-1-dev rpm -y; fi
 
 script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then npm test && npm run build:linux; fi

--- a/packages/app/app/components/Dashboard/GenresTab/mapGenres.js
+++ b/packages/app/app/components/Dashboard/GenresTab/mapGenres.js
@@ -27,14 +27,13 @@ import trending from '../../../../resources/musicgenresicons/outline/trending.sv
 import vocal from '../../../../resources/musicgenresicons/outline/vocal.svg';
 
 export default genre => {
-  switch (genre) {
+  switch (genre.toLowerCase()) {
   case 'blues':
     return blues;
   case 'rock':
   case 'classic rock':
   case 'post-rock':
   case 'progressive rock':
-  case 'Progressive rock':
     return rock;
   case 'country':
     return country;
@@ -82,12 +81,11 @@ export default genre => {
   case 'punk rock':
   case 'hardcore':
     return punk;
-  case 'Hip-Hop':
+  case 'hip-hop':
   case 'hip hop':
   case 'rap':
     return hiphop;
   case 'classical':
-  case 'Classical':
   case 'instrumental':
   case 'soundtrack':
     return classical;

--- a/packages/app/app/components/Dashboard/GenresTab/styles.scss
+++ b/packages/app/app/components/Dashboard/GenresTab/styles.scss
@@ -62,7 +62,7 @@
     flex-flow: column;
     justify-content: center;
     align-items: center;
-    font-size: 1.5rem;
+    font-size: 1rem;
     letter-spacing: 4px;
     text-transform: uppercase;
     text-align: center;


### PR DESCRIPTION
Decrease font size of genre's title as it was overflowing. Match genre's names in lower case to reduce cases.