### PR TITLE
fix(build): add icon dir path to electron-builder linux config

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
       }
     ],
     "linux": {
+      "icon": "./build/",
       "desktop": {
         "Name": "Nuclear",
         "Name[es]": "Reproductor de música Nuclear",


### PR DESCRIPTION
see simon brandner comment https://github.com/electron-userland/electron-builder/issues/2577
fix#737

I have no debian at my hand so i didn't test it, if someone could do before merge :)