### PR TITLE
Fixed bug for the \Add All\ button

### DIFF
--- a/packages/app/app/components/ArtistView/PopularTracks/index.js
+++ b/packages/app/app/components/ArtistView/PopularTracks/index.js
@@ -91,7 +91,9 @@ export default compose(
     toggleExpand: ({ expanded, setExpanded }) => () => setExpanded(!expanded),
     handleAddAll: ({ artist, tracks, expanded, streamProviders, addToQueue }) => () => 
       tracks
-        .slice(0, expanded ? 15 : 5)
+		//Change of WildLeons
+	    //Old version : .slice(0, expanded ? 15 : 5)
+        .slice(0, tracks.length > 15 ? 15 : tracks.length)
         .map(track => {
           addToQueue(streamProviders, {
             artist: artist.name,


### PR DESCRIPTION
Hello,
I've been testing stuff to fix this bug and it seems to be working.

I replaced line 94: ".slice(0, expanded ? 15 : 5)"
by ".slice(0, tracks.length > 15 ? 15 : tracks.length)"

The old line required to first scroll down the list before adding the trackss to get all of them otherwise we only have the first 5.
Now it is not necessary to do this anymore and I checked for artists who have less than 15 tracks to be sure than it will work, I tested with artists like "GRIGRI" for example.