### PR TITLE
Make tracks in Local Library visible at small screen widths

### DIFF
--- a/packages/app/app/components/LibraryView/LibrarySimpleList/styles.scss
+++ b/packages/app/app/components/LibraryView/LibrarySimpleList/styles.scss
@@ -49,3 +49,42 @@
     }
   }
 }
+
+/* Override Semantic UI small screen styles */
+@media only screen and (max-width: 767px) {
+  .library_simple_list {
+    .thead {
+      display: table-header-group !important;
+    }
+  }
+  .ui.table:not(.unstackable) .tbody {
+    display: table-row-group !important;
+  }
+  .ui.table:not(.unstackable) tr {
+    display: table-row !important;
+  }
+  .ui.table:not(.unstackable) tr>td,
+  .ui.table:not(.unstackable) tr>th {
+    display: table-cell !important;
+    padding: 0 !important;
+  }
+  .ui.table:not(.unstackable) tr>td {
+    border-bottom: 2px solid $background3 !important;
+  }
+  /* table header */
+  .ui.table:not(.unstackable) tr>th {
+    max-width: 42px !important;
+    padding-top: 0.928571em !important;
+    padding-bottom: 0.928571em !important;
+    border-bottom: 0.5px solid rgba($white, 0.2) !important;
+  }
+  /* picture icon header thing */
+  .ui.table:not(.unstackable) tr>th:nth-child(1) {
+    width: 42px !important;
+  }
+  /* artist column */
+  .ui.table:not(.unstackable) tr>th:nth-child(2),
+  .ui.table:not(.unstackable) tr>td:nth-child(2) {
+    padding-left: 0.785714em !important;
+  }
+}


### PR DESCRIPTION
[Link to issue](https://github.com/nukeop/nuclear/issues/784)

## To test:

- Open up dev tools
- Go to 'Local Library' (icon at the very bottom of the left pane)
- Expand the dev tools such that nuclear's screen width is <767px

### Before:

- Observe that track information 'disappears' and becomes unusable

### Now:

- Observe that track information is visible in the same format as when the screen is >767px

P.S. thanks to nuke here's a [link](https://github.com/Semantic-Org/Semantic-UI-CSS/blob/fc9f8bd7e4f5934756ec60c0423f77d1c7be7c6f/components/table.css#L151) to the Semantic UI styles that have been overridden