### PR TITLE
Scale down bottom player bar <=767px screen width

### DIFF
--- a/packages/ui/lib/components/Cover/styles.scss
+++ b/packages/ui/lib/components/Cover/styles.scss
@@ -11,3 +11,11 @@
   width: 76px;
   height: 76px;
 }
+
+@media (max-width: 767px) {
+  .nuclear.cover_container,
+  .nuclear.cover_container img {
+    width: 50px;
+    height: 50px;
+  }
+}

--- a/packages/ui/lib/components/PlayerBar/styles.scss
+++ b/packages/ui/lib/components/PlayerBar/styles.scss
@@ -37,3 +37,11 @@
     pointer-events: none;
   }
 }
+
+@media (max-width: 767px) {
+  .player_bar {
+    .player_bar_bottom {
+      font-size: 0.7em;
+    }
+  }
+}

--- a/packages/ui/lib/components/Range/index.js
+++ b/packages/ui/lib/components/Range/index.js
@@ -23,7 +23,8 @@ const Range = ({
   hideThumb,
   thumbColor,
   readOnly,
-  onChange
+  onChange,
+  rangeRef
 }) => {
   const handleChange = useCallback(
     e => {
@@ -41,7 +42,7 @@ const Range = ({
   const trackPosition = getTrackPosition({ thumbSize, height });
 
   return (
-    <div className={styles.range} style={{ width }}>
+    <div className={styles.range} style={{ width }} ref={rangeRef}>
       <div
         className={styles.baseDiv}
         style={{
@@ -106,7 +107,8 @@ Range.defaultProps = {
   max: 100,
   width: 300,
   value: 0,
-  onChange: () => { }
+  onChange: () => { },
+  rangeRef: null
 };
 
 const colorWithAlpha = {

--- a/packages/ui/lib/components/TrackInfo/styles.scss
+++ b/packages/ui/lib/components/TrackInfo/styles.scss
@@ -40,3 +40,15 @@
     }
   }
 }
+
+@media (max-width: 767px) {
+  .track_info {
+    .track_name {
+      font-size: 16px;
+      overflow: hidden;
+    }
+    .artist_name {
+      font-size: 12px;
+    }
+  }
+}


### PR DESCRIPTION
### What and why

I've made the bottom player bar with the track info & playback controls shrink at screen widths <= 767px (which is when the Semantic UI 'small' breakpoint hits). This makes it easier to use the controls at smaller screen widths.

### What's been tested

- The `useEffect` hook in `VolumeSlider` only runs once at mount :100:
- Performance feels the same


### Potential Issues

- New prop on the `Range` component (`.../ui/lib/components/Range`)

Added:
```
<div ... ref={rangeRef}>
```
Reason to do so is to prevent `VolumeSlider` from re-rendering unnecessarily (`resize` event listener in `VolumeSlider` uses the DOM state from this `ref` directly instead of having to go through a `useState` in `VolumeSlider`, which would involve removing and setting new `resize` event listeners whenever the `useState` state changed).

Anyways, not sure if the default prop `rangeRef: null` will work. Not sure if anything other than `VolumeSlider` renders `Range`, though.

If other components do render `Range`, init'ing and passing 
```
const dummyRef = useState(null);
...
    rangeRef={dummyRef}
``` 
would prevent any errors, if `null` turns out to not work.

If this is too sketch I could just remove the new prop from `Range` and keep everything local to `VolumeSlider`. That would mean `useEffect` would run more often but honestly people probably aren't re-sizing the application very often so I'm guessing the performance won't really be affected either way. Everything seemed smooth to me while testing.