### PR TITLE
 Ability to delete albums from favorite albums page

### DIFF
--- a/packages/app/app/components/FavoriteAlbumsView/index.js
+++ b/packages/app/app/components/FavoriteAlbumsView/index.js
@@ -22,7 +22,7 @@ const EmptyState = () => {
 
 const FavoriteAlbumsView = ({
   albums,
-  // removeFavoriteAlbum,
+  removeFavoriteAlbum,
   albumInfoSearch,
   history
 }) => {
@@ -45,6 +45,7 @@ const FavoriteAlbumsView = ({
                 albums={albums}
                 albumInfoSearch={albumInfoSearch}
                 history={history}
+                removeFavoriteAlbum={removeFavoriteAlbum}
               />
             </Segment>
           </>

--- a/packages/ui/lib/components/AlbumGrid/index.tsx
+++ b/packages/ui/lib/components/AlbumGrid/index.tsx
@@ -14,6 +14,7 @@ import styles from './styles.scss';
 const AlbumGrid = ({
   albums,
   onAlbumClick,
+  removeFavoriteAlbum,
   selectedAlbum,
   loading,
   trackButtons,
@@ -40,6 +41,15 @@ const AlbumGrid = ({
               content={withArtistNames && _.get(album, 'artist.name')}
               image={getThumbnail(album)}
               onClick={() => onAlbumClick(album)}
+              withMenu={removeFavoriteAlbum ? true : false}
+              menuEntries={[
+                {
+                  type: 'item', props: {
+                    children: 'Remove',
+                    onClick: () => removeFavoriteAlbum(album)
+                  }
+                }
+              ]}
             />
           ))
       }
@@ -65,6 +75,7 @@ AlbumGrid.propTypes = {
   albums: PropTypes.array,
   streamProviders: PropTypes.array, // eslint-disable-line react/no-unused-prop-types
   onAlbumClick: PropTypes.func,
+  removeFavoriteAlbum: PropTypes.func,
   loading: PropTypes.bool,
   addToQueue: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
   clearQueue: PropTypes.func, // eslint-disable-line react/no-unused-prop-types

--- a/packages/ui/lib/components/Card/index.tsx
+++ b/packages/ui/lib/components/Card/index.tsx
@@ -70,7 +70,9 @@ const Card: React.FC<CardProps> = ({
         }
         <div className={styles.thumbnail}
           style={{ backgroundImage: `url('${(_.isNil(image) || _.isEmpty(image)) ? artPlaceholder : image}')` }}
-        />
+        >
+          <div className={styles.overlay} />
+        </div>
         <div className={styles.card_content}>
           <h4>{header}</h4>
           {

--- a/packages/ui/lib/components/Card/styles.scss
+++ b/packages/ui/lib/components/Card/styles.scss
@@ -7,6 +7,7 @@
 
   .card {
     @include roundCorners;
+    position: relative;
     display: flex;
     flex-flow: column;
 
@@ -17,7 +18,23 @@
 
     &.animated:hover {
       box-shadow: 0 0.5rem 1rem 0 rgba(0, 0, 0, 0.2);
-      transform: scale(1.1);
+      
+      .overlay {
+        opacity: 1;
+      }
+    }
+
+    .overlay {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 100%;
+      width: 100%;
+      opacity: 0;
+      transition: .5s ease;
+      background-color: rgba(0, 0, 0, 0.4);
     }
 
     .thumbnail {


### PR DESCRIPTION
closes  #723,

# Feature Request
- ability to delete albums from favorite albums page

# Screenshots
### Before ⬇️ 
![image](https://user-images.githubusercontent.com/43148654/98586895-ad86de00-22c9-11eb-9b92-85bd08a2f2dd.png)
### After ⬇️ 
![image](https://user-images.githubusercontent.com/43148654/98586926-baa3cd00-22c9-11eb-8319-d52aefd0b90e.png)

# Extra 
- I also changed `onhover` behavior of the card, there was a problem with an opened dropdown menu and scaling card next to one with an open menu, during the transform process the menu was under the scaling card (if only if it was a sibling card)
- see the visualization of the problem
- so I used overlay
### Bug ⬇️ 
![image](https://user-images.githubusercontent.com/43148654/98588564-2be47f80-22cc-11eb-8bb4-466d6181ffff.png)

