### PR TITLE
Fix for track-recognition error breaking library scan

### DIFF
--- a/packages/main/src/services/local-library/index.ts
+++ b/packages/main/src/services/local-library/index.ts
@@ -76,10 +76,14 @@ class LocalLibrary {
     const formattedMetas = await Promise.all(filesPath.map((file, i) => this.formatMeta(metas[i], file)));
 
     if (this.config.isConnected) {
-      const formattedMetasWithoutName = formattedMetas.filter(meta => !meta.name);
-  
-      if (formattedMetasWithoutName.length) {
-        await this.fetchAcousticIdBatch(formattedMetasWithoutName, onProgress);
+      try {
+        const formattedMetasWithoutName = formattedMetas.filter(meta => !meta.name);
+
+        if (formattedMetasWithoutName.length) {
+          await this.fetchAcousticIdBatch(formattedMetasWithoutName, onProgress);
+        }
+      } catch (er) {
+        // simply catch the error (already console-logged); track recognition should not break whole local-library scan
       }
     }
 


### PR DESCRIPTION
Added a fix for the issue mentioned here: https://github.com/nukeop/nuclear/issues/720#issuecomment-689836722

This pull request adds a try-catch to the code processing the metadata returned by acoustic-id for a set of tracks.

Previously, if an error was encountered during this metadata processing (eg. "Empty fingerprint", as I hit), it would cause the entire local-library scanning process to fail. This was terrible for the user-experience, as it made Nuclear as a whole unusable, even if only a couple files in the library had the track-recognition issue.