### PR TITLE
Fix to handle acoustid-id result with no artist field

### DIFF
--- a/packages/main/src/services/local-library/index.ts
+++ b/packages/main/src/services/local-library/index.ts
@@ -115,7 +115,7 @@ class LocalLibrary {
 
       if (data && data.recordings && data.recordings.length) {
         meta.name = data.recordings[0].name;
-        meta.artist = data.recordings[0].artists[0].name || 'unknown';
+        meta.artist = data.recordings[0].artists?.[0].name || 'unknown';
       }
 
       if (!meta.name) {


### PR DESCRIPTION
The acoustic-id service can apparently sometimes return a result with the track name, but no artist field. This pull-request fixes the result-handling code, to account for this possibility without erroring. (it now just stores "unknown" as the artist name, if this case is hit)

This fix should hopefully also resolve the library-scanning fail issue seen here: https://github.com/nukeop/nuclear/issues/720

(Though it's possible the issue that user hit was a different one. Either way, the issue above is fixed by this pull-request, and it's one I've hit myself.)