### PR TITLE
updated readme to reflect packages and maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ Here's a list of packages for various managers, most of which are maintained by 
 
 | Package type   | Link                                                    | Maintainer                                    |
 |:--------------:|:-------------------------------------------------------:|:---------------------------------------------:|
-| AUR (Arch)     | https://aur.archlinux.org/packages/nuclear-player-bin/  | [mikelpint](https://github.com/mikelpint)     |
+| AUR (Arch)     | https://aur.archlinux.org/packages/nuclear-player-bin/  | [advaithm](https://github.com/advaithm)       |
+| AUR (Arch)     | https://aur.archlinux.org/packages/nuclear-player-git   | [advaithm](https://github.com/advaithm)       |
 | Choco (Win)    | https://chocolatey.org/packages/nuclear/                | [JourneyOver](https://github.com/JourneyOver) |
 | Homebrew (Mac) | https://formulae.brew.sh/cask/nuclear                   | Homebrew                                      |
 | Snap           | https://snapcraft.io/nuclear                            | [nukeop](https://github.com/nukeop)           |
-| Flatpak        | https://flathub.org/apps/details/org.js.nuclear.Nuclear | [advaithm](https://github.com/advaithm)       |
+| Flatpak        | https://flathub.org/apps/details/org.js.nuclear.Nuclear  | [advaithm](https://github.com/advaithm)       |
 
 big thanks to [ayyeve](https://github.com/ayyEve) for letting me (advaithm) use her server as a compile machine.
 ## Community translations


### PR DESCRIPTION
I recently adopted the nuclear-play-bin package on arch linux and created the nuclear-player-git package I have updated the readme to reflect this