### PR TITLE
Add report issue button in help view

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -30,6 +30,9 @@
 ### app:
  - dashboard
 
+### help:
+ - report
+
 ### library:
  - album
  - no-search-results
@@ -89,6 +92,9 @@
  - header
  - name
  - status
+
+### help:
+ - report
 
 ### library:
  - album
@@ -155,6 +161,9 @@
 ### favorites:
  - artist
 
+### help:
+ - report
+
 ### library:
  - album
  - artist
@@ -201,6 +210,9 @@
 
 ### app:
  - plugins
+
+### help:
+ - report
 
 ### library:
  - no-search-results
@@ -265,6 +277,9 @@
 ### downloads:
  - status
 
+### help:
+ - report
+
 ### library:
  - album
 
@@ -298,6 +313,9 @@
 
 ## gr
 
+### help:
+ - report
+
 ### option-control:
  - autoradio
 
@@ -314,6 +332,9 @@
 
 ### downloads:
  - status
+
+### help:
+ - report
 
 ### library:
  - album
@@ -341,6 +362,9 @@
 
 ### downloads:
  - status
+
+### help:
+ - report
 
 ### library:
  - album
@@ -395,6 +419,9 @@
 
 ## is
 
+### help:
+ - report
+
 ### search:
  - clear-history
  - last-searches
@@ -420,6 +447,9 @@
 
 ### artist:
  - count
+
+### help:
+ - report
 
 ### library:
  - album
@@ -474,6 +504,7 @@
  - about
  - header
  - released
+ - report
  - thanks
 
 ### library:
@@ -554,6 +585,9 @@
  - empty-help
  - header
 
+### help:
+ - report
+
 ### library:
  - album
  - empty
@@ -611,6 +645,9 @@
 
 ### downloads:
  - status
+
+### help:
+ - report
 
 ### library:
  - album
@@ -692,6 +729,7 @@
  - about
  - header
  - released
+ - report
  - thanks
 
 ### library:
@@ -769,6 +807,9 @@
  - empty-help
  - header
 
+### help:
+ - report
+
 ### library:
  - empty
  - empty-help
@@ -829,6 +870,9 @@
 ### favorites:
  - artist
 
+### help:
+ - report
+
 ### library:
  - album
  - artist
@@ -863,6 +907,9 @@
 
 ### app:
  - dashboard
+
+### help:
+ - report
 
 ### library:
  - album
@@ -908,6 +955,9 @@
  - youtube
 
 ## sq
+
+### help:
+ - report
 
 ### library:
  - album
@@ -963,6 +1013,7 @@
 
 ### help:
  - released
+ - report
 
 ### library:
  - album
@@ -1057,6 +1108,7 @@
 
 ### help:
  - released
+ - report
 
 ### library:
  - no-search-results
@@ -1169,6 +1221,9 @@
  - empty-help
  - header
 
+### help:
+ - report
+
 ### library:
  - empty
  - empty-help
@@ -1239,6 +1294,7 @@
 ### help:
  - header
  - released
+ - report
  - thanks
 
 ### library:

--- a/packages/app/app/components/HelpModal/index.js
+++ b/packages/app/app/components/HelpModal/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import electron from 'electron';
 import cx from 'classnames';
-import { Header, Image, Modal, Icon } from 'semantic-ui-react';
+import { Button, Header, Image, Modal, Icon } from 'semantic-ui-react';
 import { useTranslation } from 'react-i18next';
 
 import { withHandlers, compose } from 'recompose';
@@ -21,13 +21,13 @@ const HelpModal = ({
   handleTwitterClick,
   handleMastodonClick,
   handleDiscordClick,
+  handleReportIssueClick,
   githubContrib
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const handleOpen = useCallback(() => setIsOpen(true), []);
   const handleClose = useCallback(() => setIsOpen(false), []);
   const { t } = useTranslation('help');
-
   return (
     <Modal
       open={isOpen}
@@ -53,6 +53,11 @@ const HelpModal = ({
           <p>
             {t('thanks')}
           </p>
+          <Button
+            inverted
+            onClick={handleReportIssueClick}
+            content={t('report')}
+          />
         </Modal.Description>
       </Modal.Content>
       <Modal.Content>
@@ -86,6 +91,7 @@ export default compose(
     handleGithubClick: () => link => electron.shell.openExternal(_.defaultTo(link, 'https://github.com/nukeop/nuclear')),
     handleTwitterClick: () => () => electron.shell.openExternal('https://twitter.com/nuclear_player'),
     handleAuthorClick: () => () => electron.shell.openExternal('https://github.com/nukeop'),
-    handleDiscordClick: () => () => electron.shell.openExternal('https://discord.gg/JqPjKxE')
+    handleDiscordClick: () => () => electron.shell.openExternal('https://discord.gg/JqPjKxE'),
+    handleReportIssueClick: () => () => electron.shell.openExternal('https://github.com/nukeop/nuclear/issues/new?assignees=&labels=bug&template=bug_report.md&title=')
   })
 )(HelpModal);

--- a/packages/i18n/src/locales/cs.json
+++ b/packages/i18n/src/locales/cs.json
@@ -64,6 +64,7 @@
     "about": "O hudebním přehrávači Nuclear",
     "header": "Desktopový přehrávač hudby pro streamování z volně dostupných zdrojů",
     "released": "Vydán pod licencí AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Mnoho díků našim přispěvatelům na Githubu, vaše pomoc byla při vytváření tohoto programu velmi důležitá."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/de.json
+++ b/packages/i18n/src/locales/de.json
@@ -64,6 +64,7 @@
     "about": "Über Nuclear Music Player",
     "header": "Desktop-Musikplayer für das Streaming aus freien Quellen",
     "released": "veröffentlicht unter AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Vielen Dank an unsere Mitwirkenden bei Github, Ihre Hilfe war entscheidend für die Entwicklung dieses Programms."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/dk.json
+++ b/packages/i18n/src/locales/dk.json
@@ -64,6 +64,7 @@
     "about": "Om Nuclear Music Player",
     "header": "Desktop music player for streaming fra gratis kilder",
     "released": "Udgivet under AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Mange tak til Githubs brugere der har bidraget til projektet. Jeres hjælp har været afgørende i skabelsen af dette program."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -64,6 +64,7 @@
     "about": "About Nuclear Music Player",
     "header": "Desktop music player for streaming from free sources",
     "released": "released under AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Many thanks to our contributors on Github, your help was vital in creating this program."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -64,6 +64,7 @@
     "about": "Acerca de Nuclear Music Player",
     "header": "Reproductor de música de escritorio de fuentes libres",
     "released": "Distribuido bajo licencia AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Agradecemos a todos nuestros contribuyentes en GitHub, su ayuda ha sido vital en la creación de este programa"
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/fr.json
+++ b/packages/i18n/src/locales/fr.json
@@ -64,6 +64,7 @@
     "about": "À propos de \"Nuclear Music Player\"",
     "header": "Application de bureau jouant de la musique à partir de sources libres.",
     "released": "distribué sous licence AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Un grand merci à tous nos contributeurs sur Github."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/gr.json
+++ b/packages/i18n/src/locales/gr.json
@@ -64,6 +64,7 @@
     "about": "Περισσότερα για τον \"Nuclear Music Player\"",
     "header": "Εφαρμογή αναπαραγωγής μουσικής από δωρεάν πηγές στο διαδίκτυο.",
     "released": "Διατίθεται βάσει του AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Ευχαριστούμε εγκάρδια τους ανθρώπους που μας βοηθούν στο GitHub."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/hr.json
+++ b/packages/i18n/src/locales/hr.json
@@ -64,6 +64,7 @@
     "about": "O Nuclear Music Playeru",
     "header": "Desktop glazbeni player za streamanje iz besplatnih izvora",
     "released": "objavljen pod licencom AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Puno hvala svim našim suradnicima na Githubu, vaša pomoć je bila ključna u stvaranju ovog programa."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/id.json
+++ b/packages/i18n/src/locales/id.json
@@ -64,6 +64,7 @@
     "about": "Tentang Nuclear Music Player",
     "header": "Pemutar musik desktop untuk streaming dari penyedia-penyedia bebas biaya",
     "released": "dirilis dengan lisensi AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Terima kasih untuk para kontributor di Github atas peran pentingnya dalam pengembangan program ini."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/is.json
+++ b/packages/i18n/src/locales/is.json
@@ -64,6 +64,7 @@
     "about": "Um Nuclear Music Player",
     "header": "Tónlistaspilari sem streymir lög frá frium stöðum",
     "released": "Gefið út undir AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Miklar þakkir til allra sem gáfu sitt framlag á Github, þín hjálp var mikilvæg í sköpun á þessu forriti."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/it.json
+++ b/packages/i18n/src/locales/it.json
@@ -64,6 +64,7 @@
     "about": "A riguardo di Nuclear Music Player",
     "header": "Riproduttore musicale desktop che riproduce musica da fonti gratuite",
     "released": "rilasciata sotto AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Grazie mille ai contributori su GitHub, il vostro aiuto e' stato vitale nel creare questo programma."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/ko.json
+++ b/packages/i18n/src/locales/ko.json
@@ -64,6 +64,7 @@
     "about": "About Nuclear Music Player",
     "header": "Desktop music player for streaming from free sources",
     "released": "released under AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Many thanks to our contributors on Github, your help was vital in creating this program."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/nl.json
+++ b/packages/i18n/src/locales/nl.json
@@ -64,6 +64,7 @@
     "about": "Over Nuclear Music Player",
     "header": "Muziekspeler voor het streamen van vrije muziek",
     "released": "uitgebracht onder de AGPL-3.0-licentie",
+    "report": "Submit issues or new features",
     "thanks": "Hartelijk dank aan alle bijdragers op GitHub; zonder jullie was het niet gelukt."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/pl.json
+++ b/packages/i18n/src/locales/pl.json
@@ -64,6 +64,7 @@
     "about": "O Nuclear Music Player",
     "header": "Desktopowy odtwarzacz muzyki do strumieniowania z darmowych źródeł",
     "released": "wydany na licencji AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Podziękowania dla współtwórców z serwisu Github, Wasza pomoc była nieoceniona w tworzeniu tego programu."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/pt_br.json
+++ b/packages/i18n/src/locales/pt_br.json
@@ -64,6 +64,7 @@
     "about": "About Nuclear Music Player",
     "header": "Desktop music player for streaming from free sources",
     "released": "released under AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Many thanks to our contributors on Github, your help was vital in creating this program."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -64,6 +64,7 @@
     "about": "О программе Nuclear Music Player",
     "header": "Проигрыватель музыки из безплатных интернет источников",
     "released": "выпущен под лицензией AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Большое спасибо нашим участникам на Github, ваша помощь была жизненно важна в создании этой программы."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/se.json
+++ b/packages/i18n/src/locales/se.json
@@ -64,6 +64,7 @@
     "about": "Om Nuclear Music Player",
     "header": "Musikspelare som streamar från avgiftsfria källor",
     "released": "släppt under AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Stort tack till alla som bidragit på GitHub, er hjälp har varit ovärderlig i skapandet av detta program."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/sk.json
+++ b/packages/i18n/src/locales/sk.json
@@ -64,6 +64,7 @@
     "about": "O Nuclear Music Player",
     "header": "Desktopový prehrávač hudby na streamovanie hudby z voľne dostupnyých zdrojov",
     "released": "vydaný pod AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Veľká vďaka patrí prispievateľom na Githube, Vaša pomoc bola neoceniteľná."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/sq.json
+++ b/packages/i18n/src/locales/sq.json
@@ -64,6 +64,7 @@
     "about": "Rreth Nuclear Music Player",
     "header": "Aplikacion desktop për të dëgjuar muzikë nga burime të hapura",
     "released": "publikuar nën licensën AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Shumë falenderime për kontribuesit në Github, ndihma juaj ishte e rëndësishme për krijimin e këtij programi."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/tl.json
+++ b/packages/i18n/src/locales/tl.json
@@ -64,6 +64,7 @@
     "about": "Tungkol sa Nuclear Music Player",
     "header": "Desktop music player para sa streaming mula sa libreng pinanggalingan",
     "released": "released under AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Salamat sa mga nag-aambag sa Github. Ang iyong tulong ay mahalaga sa paggawa nitong programa."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/tr.json
+++ b/packages/i18n/src/locales/tr.json
@@ -64,6 +64,7 @@
     "about": "Nuclear müzik  oynatıcısı hakkında",
     "header": "Açık kaynaklı masaüstü müzik oynatıcısı",
     "released": "released under AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Github'taki katılımcılarımıza çok teşekkür ederiz.Katkılarınız bu programı yaratmamıza çok destek oldu"
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/vi.json
+++ b/packages/i18n/src/locales/vi.json
@@ -64,6 +64,7 @@
     "about": "Giới thiệu về Nuclear Music Player",
     "header": "Trình phát nhạc miễn phí cho việc streaming trên máy tính.",
     "released": "Phát hành dựa trên tiêu chuẩn AGPL-3.0",
+    "report": "Báo cáo lỗi hoặc cải tiến chức năng",
     "thanks": "Cám ơn những đóng góp của các bạn trên nền tảng Github, sự giúp đỡ của bạn rất quan trọng trong việc tạo nên chương trình này."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/zh.json
+++ b/packages/i18n/src/locales/zh.json
@@ -64,6 +64,7 @@
     "about": "关于",
     "header": "Desktop music player for streaming from free sources",
     "released": "released under AGPL-3.0",
+    "report": "Submit issues or new features",
     "thanks": "Many thanks to our contributors on Github, your help was vital in creating this program."
   },
   "input-dialog": {

--- a/packages/i18n/src/locales/zh_tw.json
+++ b/packages/i18n/src/locales/zh_tw.json
@@ -64,6 +64,7 @@
     "about": "關於",
     "header": "免費的串流播放軟體",
     "released": "遵循 AGPL-3.0 發行",
+    "report": "Submit issues or new features",
     "thanks": "非常感謝 Github 上貢獻者的貢獻，您的貢獻對本程式的誕生至關重要。"
   },
   "input-dialog": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12780733/107852189-f490ec00-6e41-11eb-8f82-1131978d2b6c.png)

It will open this link [https://github.com/nukeop/nuclear/issues/new?assignees=&labels=bug&template=bug_report.md&title=](https://github.com/nukeop/nuclear/issues/new?assignees=&labels=bug&template=bug_report.md&title=)

I think it will be useful when nuclear has more users. 

However, I don't know whether add it in `help view` or not. Other possible locations are: `developer settings `or make a popup when click on` help` icon like this:
![image](https://user-images.githubusercontent.com/12780733/107852350-de376000-6e42-11eb-93f6-8f78e902aae4.png)

