### PR TITLE
handle sub_tracks from discogs

### DIFF
--- a/packages/core/src/plugins/meta/discogs.ts
+++ b/packages/core/src/plugins/meta/discogs.ts
@@ -80,9 +80,19 @@ class DiscogsMetaProvider extends MetaProvider {
   discogsReleaseInfoToGeneric(release: DiscogsReleaseInfo, releaseType: AlbumType): AlbumDetails {
     const artist = _.head(release.artists).name;
     const coverImage = this.getCoverImage(release);
+    const tracklist: Track[] = [];
+
+    release.tracklist.forEach(track => {
+      if (track.sub_tracks) {
+        track.sub_tracks.forEach(subTrack => tracklist.push(this.discogsTrackToGeneric(subTrack, artist)));
+      } else {
+        tracklist.push(this.discogsTrackToGeneric(track, artist));
+      }
+    });
 
     return {
       ...release,
+      tracklist,
       resourceUrl: release.resource_url,
       id: `${release.id}`,
       artist: _.head(release.artists).name,
@@ -91,8 +101,7 @@ class DiscogsMetaProvider extends MetaProvider {
       images: _.map(release.images, 'resource_url'),
       genres: [..._.map(release.genres), ..._.map(release.styles)],
       type: releaseType,
-      year: `${release.year}`,
-      tracklist: _.map(release.tracklist, track => this.discogsTrackToGeneric(track, artist))
+      year: `${release.year}`
     };
   }
 

--- a/packages/core/src/rest/Discogs.types.ts
+++ b/packages/core/src/rest/Discogs.types.ts
@@ -100,4 +100,5 @@ export type DiscogsTrack = {
   extraartists?: {
     name: string;
   }[];
+  sub_tracks?: DiscogsTrack[];
 }


### PR DESCRIPTION
before: 
<img width="709" alt="Screen Shot 2021-03-09 at 14 26 03" src="https://user-images.githubusercontent.com/12780733/110435968-3e3dc100-80e6-11eb-86c6-41aa5ebad9fb.png">

after:
<img width="759" alt="Screen Shot 2021-03-09 at 14 45 49" src="https://user-images.githubusercontent.com/12780733/110435982-43027500-80e6-11eb-95e9-3771e4571f70.png">

this PR partially resolve https://github.com/nukeop/nuclear/issues/863