### PR TITLE
Export util funcs in packages/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@ import 'isomorphic-fetch';
 
 export * from './settings';
 export * from './types';
-export { isElectron } from './util';
+export * from './util';
 export { transformSource, transformPluginFile } from './plugins/transform';
 
 export { default as Plugin } from './plugins/plugin';


### PR DESCRIPTION
`isValidPort` is used in `app` but has not exported in `core`