### PR TITLE
Added pagination support for Last.fm favourites

### DIFF
--- a/packages/core/src/rest/Lastfm.ts
+++ b/packages/core/src/rest/Lastfm.ts
@@ -158,7 +158,7 @@ class LastFmApi {
     ));
   }
 
-  getNumberOfLovedTracks(user: string, limit = 1): Promise<Response> {
+  getNumberOfLovedTracks(user: string, limit = 1, page = 1): Promise<Response> {
     // Note: add page value(see lastfm api) in future to allow import of
     // more than 1000 songs
     return fetch(scrobblingApiUrl +
@@ -167,7 +167,9 @@ class LastFmApi {
       '&api_key=' +
       this.key +
       '&format=json&limit=' +
-      limit,
+      limit +
+      '&page=' +
+      page,
     {
       method: 'POST'
     }

--- a/packages/core/test/lastfm.test.ts
+++ b/packages/core/test/lastfm.test.ts
@@ -73,3 +73,23 @@ test('search tracks', async t => {
 //   t.true(data.results.trackmatches.track instanceof Array);
 //   t.true(data.results.trackmatches.track.length > 0);
 // });
+
+test('get user favorite tracks', async t => {
+  const api = setupLastFmApi('2b75dcb291e2b0c9a2c994aca522ac14',
+    '2ee49e35f08b837d43b2824198171fc8');
+  const testUser = 'jaysou37'; // test user with 1000+ loved tracks
+
+  let response = await api.getNumberOfLovedTracks(testUser, 1000, 1); // limit 1000, page 1
+  let data = await response.json();
+
+  t.is(typeof data.lovedtracks, 'object');
+  t.true(data.lovedtracks.track instanceof Array);
+  t.true(data.lovedtracks.track.length === 1000);
+
+  response = await api.getNumberOfLovedTracks(testUser, 1, 2); // limit 1, page 2
+  data = await response.json();
+
+  t.is(typeof data.lovedtracks, 'object');
+  t.true(data.lovedtracks.track instanceof Array);
+  t.true(data.lovedtracks.track.length === 1);
+});


### PR DESCRIPTION
Fixes #881 

Created function `fetchPaginatedFmFavorites()` to recursively fetch all Last.fm favourites and updated parameters for API call. 

Tested with user "jaysou37" who has 1000+ favourited tracks:

<img width="1088" alt="Screen Shot 2021-03-23 at 11 09 09 PM" src="https://user-images.githubusercontent.com/35822662/112783437-52a61700-901d-11eb-9876-444eeb8dd4a0.png">

Verified all matched tracks appeared in "Favourite Tracks" section.
