### PR TITLE
Fix when title is not available by music-metadata

### DIFF
--- a/packages/main/src/services/local-library/index.ts
+++ b/packages/main/src/services/local-library/index.ts
@@ -62,7 +62,12 @@ class LocalLibrary {
       path: file,
       folder,
       duration: format.duration,
-      name: common.title,
+      name: function() {
+        if (!_.isNil(common.title)) {
+          return common.title;
+        }
+        return path.basename(file, path.extname(file));
+      }(),
       position: common.track.no,
       album: common.album,
       artist: common.artist || 'unknown',


### PR DESCRIPTION
Sometimes, common.title is not defined by music-metadata library.
So it ends up not being even inserted into the database at all, even though it is supported audio.

I feel like this is a bug from the library but for now, this workaround works.