### PR TITLE
Adding opus format support

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,10 @@
         "mimeType": "audio/ogg"
       },
       {
+        "ext": "opus",
+        "mimeType": "audio/ogg"
+      },
+      {
         "ext": "aac",
         "mimeType": "audio/aac"
       },


### PR DESCRIPTION
Hey it's me again (sorry I'll end up probably spamming pull requests).
I've just noticed that it didn't recognize opus files so I'm adding it to the original repository if you don't mind. 

The opus open audio coding format is by itself in the ogg container format and it is supported by the player, so it's safe to add it.
It seems that it is not a very much used format; except if you use youtube-dl a lot.