### PR TITLE
Added pop-up that contains volume controls when screen too small

### DIFF
--- a/packages/ui/lib/components/PlayerBar/VolumePopUp.tsx
+++ b/packages/ui/lib/components/PlayerBar/VolumePopUp.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import VolumeControls, { VolumeControlsProps } from '../VolumeControls';
+
+import { Button, Popup } from 'semantic-ui-react';
+
+export type VolumePopUpProps = VolumeControlsProps;
+
+const VolumePopUp: React.FC<VolumeControlsProps> = ({
+  volume,
+  updateVolume,
+  toggleMute,
+  isMuted,
+  playOptions
+}) => (
+  <Popup trigger={<Button>More</Button>} flowing hoverable basic>
+    <VolumeControls
+      volume={volume}
+      updateVolume={updateVolume}
+      toggleMute={toggleMute}
+      isMuted={isMuted}
+      playOptions={playOptions}
+    />
+  </Popup>
+);
+
+export default VolumePopUp;

--- a/packages/ui/lib/components/PlayerBar/VolumePopUp.tsx
+++ b/packages/ui/lib/components/PlayerBar/VolumePopUp.tsx
@@ -13,7 +13,7 @@ const VolumePopUp: React.FC<VolumeControlsProps> = ({
   isMuted,
   playOptions
 }) => (
-  <Popup trigger={<Button>More</Button>} flowing hoverable basic>
+  <Popup trigger={<Button>More</Button>} flowing hoverable basic inverted>
     <VolumeControls
       volume={volume}
       updateVolume={updateVolume}

--- a/packages/ui/lib/components/PlayerBar/index.tsx
+++ b/packages/ui/lib/components/PlayerBar/index.tsx
@@ -5,6 +5,7 @@ import Seekbar, { SeekbarProps } from '../Seekbar';
 import PlayerControls, { PlayerControlsProps } from '../PlayerControls';
 import TrackInfo, { TrackInfoProps } from '../TrackInfo';
 import VolumeControls, { VolumeControlsProps } from '../VolumeControls';
+import VolumePopUp, { VolumePopUpProps } from './VolumePopUp';
 
 import common from '../../common.scss';
 import styles from './styles.scss';
@@ -13,7 +14,8 @@ import { formatDuration } from '../../utils';
 export type PlayerBarProps = PlayerControlsProps &
   Omit<SeekbarProps, 'children'> &
   TrackInfoProps &
-  VolumeControlsProps & {
+  VolumeControlsProps &
+  VolumePopUpProps & {
     renderTrackDuration?: boolean;
     timePlayed?: number;
     timeToEnd?: number;
@@ -95,13 +97,24 @@ const PlayerBar: React.FC<PlayerBarProps> = ({
         goForwardDisabled={goForwardDisabled}
         playDisabled={playDisabled}
       />
-      <VolumeControls
-        volume={volume}
-        updateVolume={updateVolume}
-        toggleMute={toggleMute}
-        isMuted={isMuted}
-        playOptions={playOptions}
-      />
+      { window.innerWidth < 570 &&
+        <VolumePopUp 
+          volume={volume}
+          updateVolume={updateVolume}
+          toggleMute={toggleMute}
+          isMuted={isMuted}
+          playOptions={playOptions}
+        />
+      }
+      { window.innerWidth > 570 &&
+        <VolumeControls
+          volume={volume}
+          updateVolume={updateVolume}
+          toggleMute={toggleMute}
+          isMuted={isMuted}
+          playOptions={playOptions}
+        />
+      }
     </div>
   </div>
 );


### PR DESCRIPTION
I utilized detection of window size to determine whether it was needed to minimize the bottom bar or not. If the window size was too small upon load, then it will replace the volume controls with a button that triggers a pop-up on hover and will contain the same volume controls. This can also be edited to dynamically resize as well. 

I had some confusion around exactly where the VolumePopUp.tsx file should be placed so that can be moved wherever matches the structure for the project. 

<img width="506" alt="Bottom Bar Minimized" src="https://user-images.githubusercontent.com/26678300/115771377-d84a8780-a37b-11eb-9ac6-74730c6bc7a4.png">

