### PR TITLE
Remove duplicate entries for Gentoo GURU

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Here's a list of packages for various managers, some of which are maintained by 
 |:--------------:|:------------------------------------------------------------------:|:--------------------------------------------:|:---------------------------------------------:|
 | AUR (Arch)     | https://aur.archlinux.org/packages/nuclear-player-bin/             | [nukeop](https://github.com/nukeop)          | yay -s nuclear-player-bin                     |
 | AUR (Arch)     | https://aur.archlinux.org/packages/nuclear-player-git              | [nukeop](https://github.com/nukeop)          | yay -s nuclear-player-git                     |
-| GURU (Gentoo)  | https://github.com/gentoo/guru/tree/master/media-sound/nuclear-bin | [scardracs](https://github.com/scardracs)    | add guru repo and emerge --ask nuclear-bin    |
 | Choco (Win)    | https://chocolatey.org/packages/nuclear/                           | [JourneyOver](https://github.com/JourneyOver)| choco install nuclear                         |
 | GURU (Gentoo)  | https://github.com/gentoo/guru/tree/master/media-sound/nuclear-bin | [scardracs](https://github.com/scardracs)    | emerge nuclear-bin                            |
 | Homebrew (Mac) | https://formulae.brew.sh/cask/nuclear                              | Homebrew                                     | brew install --cask nuclear                   |


### PR DESCRIPTION
We don't need two identical entries there for a single package. 
In addition, sad news: scardracs has resigned from Gentoo in general and the package is now unmaintained. It should still keep working in the foreseeable future with minimal changes, though, as long as there is no major change in the way this program is meant to be built.