### PR TITLE
Add copy orginal track url button in PlayQueue popup

### DIFF
--- a/packages/app/__mocks__/electron.js
+++ b/packages/app/__mocks__/electron.js
@@ -22,5 +22,10 @@ module.exports = {
     openExternal: jest.fn(async (link) => Promise.resolve({
       link
     }))
+  },
+  clipboard: {
+    writeText: jest.fn(async (text) => Promise.resolve({
+      text
+    }))
   }
 };

--- a/packages/app/app/components/PlayQueue/QueuePopup/index.js
+++ b/packages/app/app/components/PlayQueue/QueuePopup/index.js
@@ -29,7 +29,7 @@ export const QueuePopup = ({
   copyToClipboard
 }) => {
   const triggerElement = useRef(null);
-
+  
   const handleOpen = useCallback(
     event => {
       event.preventDefault();
@@ -48,7 +48,7 @@ export const QueuePopup = ({
     const selectedStreamProvider = _.find(plugins.plugins.streamProviders, { sourceName: plugins.selected.streamProviders });
     actions.rerollTrack(selectedStreamProvider, selectedStream, track);
   };
-  
+
   const handleSelectStream = ({ track, stream }) => {
     actions.changeTrackStream(track, stream);
   };
@@ -73,7 +73,11 @@ export const QueuePopup = ({
         [styles.hidden]: !imageReady
       })}
       trigger={
-        <div ref={triggerElement} data-testid={`queue-popup-${track.uuid}`} onContextMenu={handleOpen}>
+        <div
+          ref={triggerElement}
+          data-testid={`queue-popup-${track.uuid}`}
+          onContextMenu={handleOpen}
+        >
           {trigger}
         </div>
       }

--- a/packages/app/app/components/PlayQueue/QueuePopup/index.js
+++ b/packages/app/app/components/PlayQueue/QueuePopup/index.js
@@ -69,7 +69,7 @@ export const QueuePopup = ({
         [styles.hidden]: !imageReady
       })}
       trigger={
-        <div ref={triggerElement} onContextMenu={handleOpen}>
+        <div ref={triggerElement} data-testid={`queue-popup-${track.uuid}`} onContextMenu={handleOpen}>
           {trigger}
         </div>
       }

--- a/packages/app/app/components/PlayQueue/QueuePopup/index.js
+++ b/packages/app/app/components/PlayQueue/QueuePopup/index.js
@@ -20,6 +20,8 @@ export const QueuePopup = ({
   setImageReady,
   setOpen,
   titleLabel,
+  copyTrackUrlLabel,
+  sourceLabel,
   track,
   index,
   actions,
@@ -84,6 +86,8 @@ export const QueuePopup = ({
         dropdownOptions={dropdownOptions}
         idLabel={idLabel}
         titleLabel={titleLabel}
+        copyTrackUrlLabel={copyTrackUrlLabel}
+        sourceLabel={sourceLabel}
         selectedStream={selectedStream}
         track={track}
         onRerollTrack={handleRerollTrack}
@@ -104,6 +108,8 @@ QueuePopup.propTypes = {
   isQueueItemCompact: PropTypes.bool,
   idLabel: PropTypes.string,
   titleLabel: PropTypes.string,
+  copyTrackUrlLabel: PropTypes.string,
+  sourceLabel: PropTypes.string,
   track: PropTypes.object,
   index: PropTypes.number,
   actions: PropTypes.object,

--- a/packages/app/app/components/PlayQueue/QueuePopup/index.js
+++ b/packages/app/app/components/PlayQueue/QueuePopup/index.js
@@ -1,6 +1,5 @@
 import React, { useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { clipboard } from 'electron';
 import cs from 'classnames';
 import _ from 'lodash';
 import { withState, withHandlers, withProps, compose } from 'recompose';
@@ -26,7 +25,8 @@ export const QueuePopup = ({
   index,
   actions,
   plugins,
-  selectedStream
+  selectedStream,
+  copyToClipboard
 }) => {
   const triggerElement = useRef(null);
 
@@ -53,10 +53,12 @@ export const QueuePopup = ({
     actions.changeTrackStream(track, stream);
   };
 
-  const handleCopyStreamUrl = useCallback(() => {
-    clipboard.writeText(selectedStream?.originalUrl?.length ? selectedStream.originalUrl : '');
+  const handleCopyTrackUrl = useCallback(() => {
+    if (selectedStream?.originalUrl?.length) {
+      copyToClipboard(selectedStream.originalUrl);
+    }
     handleClose();
-  }, [selectedStream, handleClose]);
+  }, [selectedStream, handleClose, copyToClipboard]);
 
   const dropdownOptions = _.map(plugins.plugins.streamProviders, s => ({
     key: s.sourceName,
@@ -93,7 +95,7 @@ export const QueuePopup = ({
         onRerollTrack={handleRerollTrack}
         onSelectStream={handleSelectStream}
         onImageLoaded={handleImageLoaded}
-        onCopyStreamUrl={handleCopyStreamUrl}
+        onCopyTrackUrl={handleCopyTrackUrl}
       />
       <hr />
       <div className={styles.queue_popup_buttons_container}>
@@ -113,7 +115,8 @@ QueuePopup.propTypes = {
   track: PropTypes.object,
   index: PropTypes.number,
   actions: PropTypes.object,
-  plugins: PropTypes.object
+  plugins: PropTypes.object,
+  copyToClipboard: PropTypes.func
 };
 
 export default compose(

--- a/packages/app/app/components/PlayQueue/QueuePopup/index.js
+++ b/packages/app/app/components/PlayQueue/QueuePopup/index.js
@@ -1,6 +1,8 @@
 import React, { useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { clipboard } from 'electron';
 import cs from 'classnames';
+import _ from 'lodash';
 import { withState, withHandlers, withProps, compose } from 'recompose';
 import { Popup } from 'semantic-ui-react';
 import { StreamInfo } from '@nuclear/ui';
@@ -49,6 +51,11 @@ export const QueuePopup = ({
     actions.changeTrackStream(track, stream);
   };
 
+  const handleCopyStreamUrl = useCallback(() => {
+    clipboard.writeText(selectedStream?.originalUrl?.length ? selectedStream.originalUrl : '');
+    handleClose();
+  }, [selectedStream, handleClose]);
+
   const dropdownOptions = _.map(plugins.plugins.streamProviders, s => ({
     key: s.sourceName,
     text: s.sourceName,
@@ -82,6 +89,7 @@ export const QueuePopup = ({
         onRerollTrack={handleRerollTrack}
         onSelectStream={handleSelectStream}
         onImageLoaded={handleImageLoaded}
+        onCopyStreamUrl={handleCopyStreamUrl}
       />
       <hr />
       <div className={styles.queue_popup_buttons_container}>

--- a/packages/app/app/components/PlayQueue/index.js
+++ b/packages/app/app/components/PlayQueue/index.js
@@ -121,6 +121,8 @@ class PlayQueue extends React.PureComponent {
                 track={el}
                 titleLabel={t('title')}
                 idLabel={t('id')}
+                copyTrackUrlLabel={t('copy-track-url')}
+                sourceLabel={t('source')}
               />
             </div>
           )}

--- a/packages/app/app/containers/PlayQueueContainer/PlayQueueContainer.test.tsx
+++ b/packages/app/app/containers/PlayQueueContainer/PlayQueueContainer.test.tsx
@@ -1,0 +1,48 @@
+// import { fireEvent, waitFor, createEvent } from '@testing-library/react';
+import { mountedPlayQueueFactory, setupI18Next } from '../../../test/testUtils';
+import { buildStoreState } from '../../../test/storeBuilders';
+
+describe('Play Queue container', () => {
+  beforeAll(() => {
+    setupI18Next();
+  });
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { store } = require('@nuclear/core');
+    store.clear();
+  });
+
+  it('should display with track in queue', () => {
+    const { component } = mountComponent();
+    expect(component.asFragment()).toMatchSnapshot();
+  });
+
+  //   it('should copy original track url to clipboard', async () => {
+  //     const { component } = mountComponent();
+  //     // eslint-disable-next-line @typescript-eslint/no-var-requires
+  //     const clipboard = require('electron').clipboard;
+
+  //     const track = component.getByTestId('queue-popup-uuid1');
+  //     await waitFor(() => fireEvent.contextMenu(track));
+  //     await waitFor(() => component.getByTestId('copy-orignal-url').click());
+  //     expect(clipboard.writeText).toHaveBeenCalledWith('https://test-track-original-url');
+  //   });
+
+  // it('should not display copy button', () => {
+  //   const { component } = mountComponent();
+  //   const track = component.getByTestId('queue-popup-uuid2');
+  //   await waitFor(() => fireEvent.contextMenu(track));
+  //   const copyButton = component.getByTestId('copy-orignal-url')
+  //   expect(copyButton),toEqual(undefined);
+  // });
+
+  const mountComponent = mountedPlayQueueFactory(
+    ['/dashboard'],
+    buildStoreState()
+      .withTrackInPlayQueue()
+      .withPlugins()
+      .withConnectivity()
+      .build()
+  );
+});

--- a/packages/app/app/containers/PlayQueueContainer/PlayQueueContainer.test.tsx
+++ b/packages/app/app/containers/PlayQueueContainer/PlayQueueContainer.test.tsx
@@ -1,4 +1,4 @@
-// import { fireEvent, waitFor, createEvent } from '@testing-library/react';
+// import { fireEvent, waitFor } from '@testing-library/react';
 import { mountedPlayQueueFactory, setupI18Next } from '../../../test/testUtils';
 import { buildStoreState } from '../../../test/storeBuilders';
 
@@ -13,7 +13,7 @@ describe('Play Queue container', () => {
     store.clear();
   });
 
-  it('should display with track in queue', () => {
+  it('should display with track in queue', async () => {
     const { component } = mountComponent();
     expect(component.asFragment()).toMatchSnapshot();
   });

--- a/packages/app/app/containers/PlayQueueContainer/PlayQueueContainer.test.tsx
+++ b/packages/app/app/containers/PlayQueueContainer/PlayQueueContainer.test.tsx
@@ -22,7 +22,7 @@ describe('Play Queue container', () => {
     const { component } = mountComponent();
     const track = component.getByTestId('queue-popup-uuid1');
     await waitFor(() => fireEvent.contextMenu(track));
-    expect(component.baseElement).toMatchSnapshot();
+    expect(component.asFragment()).toMatchSnapshot();
   });
 
   it('should copy original track url to clipboard', async () => {

--- a/packages/app/app/containers/PlayQueueContainer/PlayQueueContainer.test.tsx
+++ b/packages/app/app/containers/PlayQueueContainer/PlayQueueContainer.test.tsx
@@ -1,7 +1,6 @@
-// import { fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { mountedPlayQueueFactory, setupI18Next } from '../../../test/testUtils';
 import { buildStoreState } from '../../../test/storeBuilders';
-import { fireEvent, waitFor } from '@testing-library/react';
 
 describe('Play Queue container', () => {
   beforeAll(() => {
@@ -23,7 +22,7 @@ describe('Play Queue container', () => {
     const { component } = mountComponent();
     const track = component.getByTestId('queue-popup-uuid1');
     await waitFor(() => fireEvent.contextMenu(track));
-    expect(component.asFragment()).toMatchSnapshot();
+    expect(component.baseElement).toMatchSnapshot();
   });
 
   it('should copy original track url to clipboard', async () => {

--- a/packages/app/app/containers/PlayQueueContainer/PlayQueueContainer.test.tsx
+++ b/packages/app/app/containers/PlayQueueContainer/PlayQueueContainer.test.tsx
@@ -1,6 +1,7 @@
 // import { fireEvent, waitFor } from '@testing-library/react';
 import { mountedPlayQueueFactory, setupI18Next } from '../../../test/testUtils';
 import { buildStoreState } from '../../../test/storeBuilders';
+import { fireEvent, waitFor } from '@testing-library/react';
 
 describe('Play Queue container', () => {
   beforeAll(() => {
@@ -18,24 +19,31 @@ describe('Play Queue container', () => {
     expect(component.asFragment()).toMatchSnapshot();
   });
 
-  //   it('should copy original track url to clipboard', async () => {
-  //     const { component } = mountComponent();
-  //     // eslint-disable-next-line @typescript-eslint/no-var-requires
-  //     const clipboard = require('electron').clipboard;
+  it('should display a context popup on right click', async () => {
+    const { component } = mountComponent();
+    const track = component.getByTestId('queue-popup-uuid1');
+    await waitFor(() => fireEvent.contextMenu(track));
+    expect(component.asFragment()).toMatchSnapshot();
+  });
 
-  //     const track = component.getByTestId('queue-popup-uuid1');
-  //     await waitFor(() => fireEvent.contextMenu(track));
-  //     await waitFor(() => component.getByTestId('copy-orignal-url').click());
-  //     expect(clipboard.writeText).toHaveBeenCalledWith('https://test-track-original-url');
-  //   });
+  it('should copy original track url to clipboard', async () => {
+    const { component } = mountComponent();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const clipboard = require('electron').clipboard;
 
-  // it('should not display copy button', () => {
-  //   const { component } = mountComponent();
-  //   const track = component.getByTestId('queue-popup-uuid2');
-  //   await waitFor(() => fireEvent.contextMenu(track));
-  //   const copyButton = component.getByTestId('copy-orignal-url')
-  //   expect(copyButton),toEqual(undefined);
-  // });
+    const track = component.getByTestId('queue-popup-uuid1');
+    await waitFor(() => fireEvent.contextMenu(track));
+    await waitFor(() => component.getByTestId('copy-original-url').click());
+    expect(clipboard.writeText).toHaveBeenCalledWith('https://test-track-original-url');
+  });
+
+  it('should not display copy button', async () => {
+    const { component } = mountComponent();
+    const track = component.getByTestId('queue-popup-uuid2');
+    await waitFor(() => fireEvent.contextMenu(track));
+    const copyButton = component.queryByTestId('copy-original-url');
+    expect(copyButton).toEqual(null);
+  });
 
   const mountComponent = mountedPlayQueueFactory(
     ['/dashboard'],

--- a/packages/app/app/containers/PlayQueueContainer/__snapshots__/PlayQueueContainer.test.tsx.snap
+++ b/packages/app/app/containers/PlayQueueContainer/__snapshots__/PlayQueueContainer.test.tsx.snap
@@ -1,0 +1,244 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Play Queue container should display with track in queue 1`] = `
+<DocumentFragment>
+  <div
+    class="play_queue_container"
+  >
+    <div
+      class="queue_menu_container"
+    >
+      <div
+        class="queue_menu_buttons"
+      >
+        <a
+          class="compactButton"
+          href="#"
+        >
+          <i
+            aria-hidden="true"
+            class="angle right icon"
+          />
+        </a>
+        <div
+          aria-disabled="false"
+          aria-expanded="false"
+          class="ui item dropdown queue_menu_more"
+          role="listbox"
+          tabindex="0"
+        >
+          <i
+            aria-hidden="true"
+            class="ellipsis vertical icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              class="header"
+            >
+              Queue
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Clear queue
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="save icon"
+              />
+              Save as playlist
+            </div>
+            <div
+              class="divider"
+            />
+            <div
+              class="header"
+            >
+              Current track
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <div
+                aria-expanded="false"
+                class="ui dropdown left"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-atomic="true"
+                  aria-live="polite"
+                  class="divider text"
+                  role="alert"
+                >
+                  Add to playlist
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="dropdown icon"
+                />
+                <div
+                  class="menu transition left playlists_menu"
+                />
+              </div>
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="star icon"
+              />
+              Add to favorites
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+              Download
+            </div>
+          </div>
+        </div>
+      </div>
+      <hr />
+    </div>
+    <div
+      class="play_queue_items fade_in"
+      data-rbd-droppable-context-id="0"
+      data-rbd-droppable-id="play_queue"
+    >
+      <div
+        aria-describedby="rbd-hidden-text-0-hidden-text-0"
+        data-rbd-drag-handle-context-id="0"
+        data-rbd-drag-handle-draggable-id="uuid1+0"
+        data-rbd-draggable-context-id="0"
+        data-rbd-draggable-id="uuid1+0"
+        draggable="false"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          data-testid="queue-popup-uuid1"
+        >
+          <div
+            class="nuclear queue_item current_song"
+          >
+            <div
+              class="thumbnail"
+            >
+              <img
+                src="https://test-track-thumb-url"
+              />
+              <div
+                class="thumbnail_overlay"
+              >
+                <i
+                  aria-hidden="true"
+                  class="trash alternate outline big icon"
+                />
+              </div>
+            </div>
+            <div
+              class="item_info_container"
+            >
+              <div
+                class="name_container"
+              >
+                test track 1
+              </div>
+              <div
+                class="artist_container"
+              >
+                BTS
+              </div>
+            </div>
+            <div
+              class="item_duration_container"
+            >
+              <div
+                class="item_duration"
+              >
+                00:00
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-describedby="rbd-hidden-text-0-hidden-text-0"
+        data-rbd-drag-handle-context-id="0"
+        data-rbd-drag-handle-draggable-id="uuid2+1"
+        data-rbd-draggable-context-id="0"
+        data-rbd-draggable-id="uuid2+1"
+        draggable="false"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          data-testid="queue-popup-uuid2"
+        >
+          <div
+            class="nuclear queue_item"
+          >
+            <div
+              class="thumbnail"
+            >
+              <img
+                src="https://test-track-thumb-url"
+              />
+              <div
+                class="thumbnail_overlay"
+              >
+                <i
+                  aria-hidden="true"
+                  class="trash alternate outline big icon"
+                />
+              </div>
+            </div>
+            <div
+              class="item_info_container"
+            >
+              <div
+                class="name_container"
+              >
+                test track 2
+              </div>
+              <div
+                class="artist_container"
+              >
+                BTS
+              </div>
+            </div>
+            <div
+              class="item_duration_container"
+            >
+              <div
+                class="item_duration"
+              >
+                00:00
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/app/app/containers/PlayQueueContainer/__snapshots__/PlayQueueContainer.test.tsx.snap
+++ b/packages/app/app/containers/PlayQueueContainer/__snapshots__/PlayQueueContainer.test.tsx.snap
@@ -1,246 +1,238 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Play Queue container should display a context popup on right click 1`] = `
-<body>
+<DocumentFragment>
   <div
-    aria-atomic="true"
-    aria-live="assertive"
-    id="rbd-announcement-0"
-    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
-  />
-  <div>
+    class="play_queue_container"
+  >
     <div
-      class="play_queue_container"
+      class="queue_menu_container"
     >
       <div
-        class="queue_menu_container"
+        class="queue_menu_buttons"
       >
-        <div
-          class="queue_menu_buttons"
+        <a
+          class="compactButton"
+          href="#"
         >
-          <a
-            class="compactButton"
-            href="#"
-          >
-            <i
-              aria-hidden="true"
-              class="angle right icon"
-            />
-          </a>
+          <i
+            aria-hidden="true"
+            class="angle right icon"
+          />
+        </a>
+        <div
+          aria-disabled="false"
+          aria-expanded="false"
+          class="ui item dropdown queue_menu_more"
+          role="listbox"
+          tabindex="0"
+        >
+          <i
+            aria-hidden="true"
+            class="ellipsis vertical icon"
+          />
           <div
-            aria-disabled="false"
-            aria-expanded="false"
-            class="ui item dropdown queue_menu_more"
-            role="listbox"
-            tabindex="0"
+            class="menu transition"
           >
-            <i
-              aria-hidden="true"
-              class="ellipsis vertical icon"
+            <div
+              class="header"
+            >
+              Queue
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Clear queue
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="save icon"
+              />
+              Save as playlist
+            </div>
+            <div
+              class="divider"
             />
             <div
-              class="menu transition"
+              class="header"
+            >
+              Current track
+            </div>
+            <div
+              class="item"
+              role="option"
             >
               <div
-                class="header"
+                aria-expanded="false"
+                class="ui dropdown left"
+                role="listbox"
+                tabindex="0"
               >
-                Queue
-              </div>
-              <div
-                class="item"
-                role="option"
-              >
+                <div
+                  aria-atomic="true"
+                  aria-live="polite"
+                  class="divider text"
+                  role="alert"
+                >
+                  Add to playlist
+                </div>
                 <i
                   aria-hidden="true"
-                  class="trash icon"
+                  class="dropdown icon"
                 />
-                Clear queue
-              </div>
-              <div
-                class="item"
-                role="option"
-              >
-                <i
-                  aria-hidden="true"
-                  class="save icon"
+                <div
+                  class="menu transition left playlists_menu"
                 />
-                Save as playlist
               </div>
-              <div
-                class="divider"
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="star icon"
+              />
+              Add to favorites
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+              Download
+            </div>
+          </div>
+        </div>
+      </div>
+      <hr />
+    </div>
+    <div
+      class="play_queue_items fade_in"
+      data-rbd-droppable-context-id="1"
+      data-rbd-droppable-id="play_queue"
+    >
+      <div
+        aria-describedby="rbd-hidden-text-1-hidden-text-4"
+        data-rbd-drag-handle-context-id="1"
+        data-rbd-drag-handle-draggable-id="uuid1+0"
+        data-rbd-draggable-context-id="1"
+        data-rbd-draggable-id="uuid1+0"
+        draggable="false"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          data-testid="queue-popup-uuid1"
+        >
+          <div
+            class="nuclear queue_item current_song"
+          >
+            <div
+              class="thumbnail"
+            >
+              <img
+                src="https://test-track-thumb-url"
               />
               <div
-                class="header"
-              >
-                Current track
-              </div>
-              <div
-                class="item"
-                role="option"
-              >
-                <div
-                  aria-expanded="false"
-                  class="ui dropdown left"
-                  role="listbox"
-                  tabindex="0"
-                >
-                  <div
-                    aria-atomic="true"
-                    aria-live="polite"
-                    class="divider text"
-                    role="alert"
-                  >
-                    Add to playlist
-                  </div>
-                  <i
-                    aria-hidden="true"
-                    class="dropdown icon"
-                  />
-                  <div
-                    class="menu transition left playlists_menu"
-                  />
-                </div>
-              </div>
-              <div
-                class="item"
-                role="option"
+                class="thumbnail_overlay"
               >
                 <i
                   aria-hidden="true"
-                  class="star icon"
+                  class="trash alternate outline big icon"
                 />
-                Add to favorites
+              </div>
+            </div>
+            <div
+              class="item_info_container"
+            >
+              <div
+                class="name_container"
+              >
+                test track 1
               </div>
               <div
-                class="item"
-                role="option"
+                class="artist_container"
               >
-                <i
-                  aria-hidden="true"
-                  class="download icon"
-                />
-                Download
+                BTS
+              </div>
+            </div>
+            <div
+              class="item_duration_container"
+            >
+              <div
+                class="item_duration"
+              >
+                05:00
               </div>
             </div>
           </div>
         </div>
-        <hr />
       </div>
       <div
-        class="play_queue_items fade_in"
-        data-rbd-droppable-context-id="1"
-        data-rbd-droppable-id="play_queue"
+        aria-describedby="rbd-hidden-text-1-hidden-text-4"
+        data-rbd-drag-handle-context-id="1"
+        data-rbd-drag-handle-draggable-id="uuid2+1"
+        data-rbd-draggable-context-id="1"
+        data-rbd-draggable-id="uuid2+1"
+        draggable="false"
+        role="button"
+        tabindex="0"
       >
         <div
-          aria-describedby="rbd-hidden-text-1-hidden-text-4"
-          data-rbd-drag-handle-context-id="1"
-          data-rbd-drag-handle-draggable-id="uuid1+0"
-          data-rbd-draggable-context-id="1"
-          data-rbd-draggable-id="uuid1+0"
-          draggable="false"
-          role="button"
-          tabindex="0"
+          data-testid="queue-popup-uuid2"
         >
           <div
-            data-testid="queue-popup-uuid1"
+            class="nuclear queue_item"
           >
             <div
-              class="nuclear queue_item current_song"
+              class="thumbnail"
             >
+              <img
+                src="https://test-track-thumb-url"
+              />
               <div
-                class="thumbnail"
+                class="thumbnail_overlay"
               >
-                <img
-                  src="https://test-track-thumb-url"
+                <i
+                  aria-hidden="true"
+                  class="trash alternate outline big icon"
                 />
-                <div
-                  class="thumbnail_overlay"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="trash alternate outline big icon"
-                  />
-                </div>
-              </div>
-              <div
-                class="item_info_container"
-              >
-                <div
-                  class="name_container"
-                >
-                  test track 1
-                </div>
-                <div
-                  class="artist_container"
-                >
-                  BTS
-                </div>
-              </div>
-              <div
-                class="item_duration_container"
-              >
-                <div
-                  class="item_duration"
-                >
-                  05:00
-                </div>
               </div>
             </div>
-          </div>
-        </div>
-        <div
-          aria-describedby="rbd-hidden-text-1-hidden-text-4"
-          data-rbd-drag-handle-context-id="1"
-          data-rbd-drag-handle-draggable-id="uuid2+1"
-          data-rbd-draggable-context-id="1"
-          data-rbd-draggable-id="uuid2+1"
-          draggable="false"
-          role="button"
-          tabindex="0"
-        >
-          <div
-            data-testid="queue-popup-uuid2"
-          >
             <div
-              class="nuclear queue_item"
+              class="item_info_container"
             >
               <div
-                class="thumbnail"
+                class="name_container"
               >
-                <img
-                  src="https://test-track-thumb-url"
-                />
-                <div
-                  class="thumbnail_overlay"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="trash alternate outline big icon"
-                  />
-                </div>
+                test track 2
               </div>
               <div
-                class="item_info_container"
+                class="artist_container"
               >
-                <div
-                  class="name_container"
-                >
-                  test track 2
-                </div>
-                <div
-                  class="artist_container"
-                >
-                  BTS
-                </div>
+                BTS
               </div>
+            </div>
+            <div
+              class="item_duration_container"
+            >
               <div
-                class="item_duration_container"
+                class="item_duration"
               >
-                <div
-                  class="item_duration"
-                >
-                  00:00
-                </div>
+                00:00
               </div>
             </div>
           </div>
@@ -393,8 +385,7 @@ exports[`Play Queue container should display a context popup on right click 1`] 
             aria-hidden="true"
             class="play icon"
           />
-           
-          Play now
+           Play now
         </a>
         <a
           aria-label="Add this track to favorites"
@@ -405,8 +396,7 @@ exports[`Play Queue container should display a context popup on right click 1`] 
             aria-hidden="true"
             class="star icon"
           />
-           
-          Add to favorites
+           Add to favorites
         </a>
         <a
           aria-label="Download this track"
@@ -417,13 +407,12 @@ exports[`Play Queue container should display a context popup on right click 1`] 
             aria-hidden="true"
             class="download icon"
           />
-           
-          Download
+           Download
         </a>
       </div>
     </div>
   </div>
-</body>
+</DocumentFragment>
 `;
 
 exports[`Play Queue container should display with track in queue 1`] = `
@@ -665,6 +654,22 @@ exports[`Play Queue container should display with track in queue 1`] = `
         </div>
       </div>
     </div>
+  </div>
+  <div
+    aria-atomic="true"
+    aria-live="assertive"
+    id="rbd-announcement-0"
+    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
+  />
+  <div
+    id="rbd-hidden-text-0-hidden-text-0"
+    style="display: none;"
+  >
+    
+  Press space bar to start a drag.
+  When dragging you can use the arrow keys to move the item around and escape to cancel.
+  Some screen readers may require you to be in focus mode or to use your pass through key
+
   </div>
 </DocumentFragment>
 `;

--- a/packages/app/app/containers/PlayQueueContainer/__snapshots__/PlayQueueContainer.test.tsx.snap
+++ b/packages/app/app/containers/PlayQueueContainer/__snapshots__/PlayQueueContainer.test.tsx.snap
@@ -1,238 +1,246 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Play Queue container should display a context popup on right click 1`] = `
-<DocumentFragment>
+<body>
   <div
-    class="play_queue_container"
-  >
+    aria-atomic="true"
+    aria-live="assertive"
+    id="rbd-announcement-0"
+    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
+  />
+  <div>
     <div
-      class="queue_menu_container"
+      class="play_queue_container"
     >
       <div
-        class="queue_menu_buttons"
+        class="queue_menu_container"
       >
-        <a
-          class="compactButton"
-          href="#"
-        >
-          <i
-            aria-hidden="true"
-            class="angle right icon"
-          />
-        </a>
         <div
-          aria-disabled="false"
-          aria-expanded="false"
-          class="ui item dropdown queue_menu_more"
-          role="listbox"
-          tabindex="0"
+          class="queue_menu_buttons"
         >
-          <i
-            aria-hidden="true"
-            class="ellipsis vertical icon"
-          />
-          <div
-            class="menu transition"
+          <a
+            class="compactButton"
+            href="#"
           >
-            <div
-              class="header"
-            >
-              Queue
-            </div>
-            <div
-              class="item"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="trash icon"
-              />
-              Clear queue
-            </div>
-            <div
-              class="item"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="save icon"
-              />
-              Save as playlist
-            </div>
-            <div
-              class="divider"
+            <i
+              aria-hidden="true"
+              class="angle right icon"
+            />
+          </a>
+          <div
+            aria-disabled="false"
+            aria-expanded="false"
+            class="ui item dropdown queue_menu_more"
+            role="listbox"
+            tabindex="0"
+          >
+            <i
+              aria-hidden="true"
+              class="ellipsis vertical icon"
             />
             <div
-              class="header"
-            >
-              Current track
-            </div>
-            <div
-              class="item"
-              role="option"
+              class="menu transition"
             >
               <div
-                aria-expanded="false"
-                class="ui dropdown left"
-                role="listbox"
-                tabindex="0"
+                class="header"
+              >
+                Queue
+              </div>
+              <div
+                class="item"
+                role="option"
+              >
+                <i
+                  aria-hidden="true"
+                  class="trash icon"
+                />
+                Clear queue
+              </div>
+              <div
+                class="item"
+                role="option"
+              >
+                <i
+                  aria-hidden="true"
+                  class="save icon"
+                />
+                Save as playlist
+              </div>
+              <div
+                class="divider"
+              />
+              <div
+                class="header"
+              >
+                Current track
+              </div>
+              <div
+                class="item"
+                role="option"
               >
                 <div
-                  aria-atomic="true"
-                  aria-live="polite"
-                  class="divider text"
-                  role="alert"
+                  aria-expanded="false"
+                  class="ui dropdown left"
+                  role="listbox"
+                  tabindex="0"
                 >
-                  Add to playlist
+                  <div
+                    aria-atomic="true"
+                    aria-live="polite"
+                    class="divider text"
+                    role="alert"
+                  >
+                    Add to playlist
+                  </div>
+                  <i
+                    aria-hidden="true"
+                    class="dropdown icon"
+                  />
+                  <div
+                    class="menu transition left playlists_menu"
+                  />
                 </div>
+              </div>
+              <div
+                class="item"
+                role="option"
+              >
                 <i
                   aria-hidden="true"
-                  class="dropdown icon"
+                  class="star icon"
+                />
+                Add to favorites
+              </div>
+              <div
+                class="item"
+                role="option"
+              >
+                <i
+                  aria-hidden="true"
+                  class="download icon"
+                />
+                Download
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr />
+      </div>
+      <div
+        class="play_queue_items fade_in"
+        data-rbd-droppable-context-id="1"
+        data-rbd-droppable-id="play_queue"
+      >
+        <div
+          aria-describedby="rbd-hidden-text-1-hidden-text-4"
+          data-rbd-drag-handle-context-id="1"
+          data-rbd-drag-handle-draggable-id="uuid1+0"
+          data-rbd-draggable-context-id="1"
+          data-rbd-draggable-id="uuid1+0"
+          draggable="false"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            data-testid="queue-popup-uuid1"
+          >
+            <div
+              class="nuclear queue_item current_song"
+            >
+              <div
+                class="thumbnail"
+              >
+                <img
+                  src="https://test-track-thumb-url"
                 />
                 <div
-                  class="menu transition left playlists_menu"
-                />
-              </div>
-            </div>
-            <div
-              class="item"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="star icon"
-              />
-              Add to favorites
-            </div>
-            <div
-              class="item"
-              role="option"
-            >
-              <i
-                aria-hidden="true"
-                class="download icon"
-              />
-              Download
-            </div>
-          </div>
-        </div>
-      </div>
-      <hr />
-    </div>
-    <div
-      class="play_queue_items fade_in"
-      data-rbd-droppable-context-id="1"
-      data-rbd-droppable-id="play_queue"
-    >
-      <div
-        aria-describedby="rbd-hidden-text-1-hidden-text-4"
-        data-rbd-drag-handle-context-id="1"
-        data-rbd-drag-handle-draggable-id="uuid1+0"
-        data-rbd-draggable-context-id="1"
-        data-rbd-draggable-id="uuid1+0"
-        draggable="false"
-        role="button"
-        tabindex="0"
-      >
-        <div
-          data-testid="queue-popup-uuid1"
-        >
-          <div
-            class="nuclear queue_item current_song"
-          >
-            <div
-              class="thumbnail"
-            >
-              <img
-                src="https://test-track-thumb-url"
-              />
-              <div
-                class="thumbnail_overlay"
-              >
-                <i
-                  aria-hidden="true"
-                  class="trash alternate outline big icon"
-                />
-              </div>
-            </div>
-            <div
-              class="item_info_container"
-            >
-              <div
-                class="name_container"
-              >
-                test track 1
+                  class="thumbnail_overlay"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="trash alternate outline big icon"
+                  />
+                </div>
               </div>
               <div
-                class="artist_container"
+                class="item_info_container"
               >
-                BTS
+                <div
+                  class="name_container"
+                >
+                  test track 1
+                </div>
+                <div
+                  class="artist_container"
+                >
+                  BTS
+                </div>
               </div>
-            </div>
-            <div
-              class="item_duration_container"
-            >
               <div
-                class="item_duration"
+                class="item_duration_container"
               >
-                05:00
+                <div
+                  class="item_duration"
+                >
+                  05:00
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        aria-describedby="rbd-hidden-text-1-hidden-text-4"
-        data-rbd-drag-handle-context-id="1"
-        data-rbd-drag-handle-draggable-id="uuid2+1"
-        data-rbd-draggable-context-id="1"
-        data-rbd-draggable-id="uuid2+1"
-        draggable="false"
-        role="button"
-        tabindex="0"
-      >
         <div
-          data-testid="queue-popup-uuid2"
+          aria-describedby="rbd-hidden-text-1-hidden-text-4"
+          data-rbd-drag-handle-context-id="1"
+          data-rbd-drag-handle-draggable-id="uuid2+1"
+          data-rbd-draggable-context-id="1"
+          data-rbd-draggable-id="uuid2+1"
+          draggable="false"
+          role="button"
+          tabindex="0"
         >
           <div
-            class="nuclear queue_item"
+            data-testid="queue-popup-uuid2"
           >
             <div
-              class="thumbnail"
+              class="nuclear queue_item"
             >
-              <img
-                src="https://test-track-thumb-url"
-              />
               <div
-                class="thumbnail_overlay"
+                class="thumbnail"
               >
-                <i
-                  aria-hidden="true"
-                  class="trash alternate outline big icon"
+                <img
+                  src="https://test-track-thumb-url"
                 />
+                <div
+                  class="thumbnail_overlay"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="trash alternate outline big icon"
+                  />
+                </div>
               </div>
-            </div>
-            <div
-              class="item_info_container"
-            >
               <div
-                class="name_container"
+                class="item_info_container"
               >
-                test track 2
+                <div
+                  class="name_container"
+                >
+                  test track 2
+                </div>
+                <div
+                  class="artist_container"
+                >
+                  BTS
+                </div>
               </div>
               <div
-                class="artist_container"
+                class="item_duration_container"
               >
-                BTS
-              </div>
-            </div>
-            <div
-              class="item_duration_container"
-            >
-              <div
-                class="item_duration"
-              >
-                00:00
+                <div
+                  class="item_duration"
+                >
+                  00:00
+                </div>
               </div>
             </div>
           </div>
@@ -240,7 +248,182 @@ exports[`Play Queue container should display a context popup on right click 1`] 
       </div>
     </div>
   </div>
-</DocumentFragment>
+  <div
+    aria-atomic="true"
+    aria-live="assertive"
+    id="rbd-announcement-1"
+    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
+  />
+  <div
+    id="rbd-hidden-text-1-hidden-text-4"
+    style="display: none;"
+  >
+    
+  Press space bar to start a drag.
+  When dragging you can use the arrow keys to move the item around and escape to cancel.
+  Some screen readers may require you to be in focus mode or to use your pass through key
+
+  </div>
+  <div
+    style="display: flex; position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      class="ui bottom center popup transition visible queue_popup hidden"
+      style="position: initial;"
+    >
+      <div
+        class="stream_info"
+      >
+        <div
+          class="stream_thumbnail"
+        />
+        <div
+          class="stream_text_info"
+        >
+          <div
+            class="stream_source"
+          >
+            <label>
+              Source:
+            </label>
+             
+            <div
+              aria-expanded="false"
+              class="ui inline dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="divider text"
+                role="alert"
+              >
+                Test Stream Provider
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="true"
+                  aria-selected="true"
+                  class="active selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Test Stream Provider
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    Different Stream Provider
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="stream_title"
+          >
+            <label>
+              Title:
+            </label>
+            <span>
+              test track 1
+            </span>
+          </div>
+          <div
+            class="stream_id"
+          >
+            <label>
+              Stream ID:
+            </label>
+            <span>
+              CuklIb9d3fI
+            </span>
+          </div>
+        </div>
+        <div
+          class="stream_buttons"
+        >
+          <a
+            data-testid="copy-original-url"
+            href="#"
+          >
+            <i
+              aria-hidden="true"
+              class="linkify icon"
+            />
+          </a>
+          <a
+            href="#"
+          >
+            <i
+              aria-hidden="true"
+              class="refresh icon"
+            />
+          </a>
+        </div>
+      </div>
+      <hr />
+      <div
+        class="queue_popup_buttons_container"
+      >
+        <a
+          aria-label="Play this track now"
+          class="popup_button"
+          href="#"
+        >
+          <i
+            aria-hidden="true"
+            class="play icon"
+          />
+           
+          Play now
+        </a>
+        <a
+          aria-label="Add this track to favorites"
+          class="popup_button"
+          href="#"
+        >
+          <i
+            aria-hidden="true"
+            class="star icon"
+          />
+           
+          Add to favorites
+        </a>
+        <a
+          aria-label="Download this track"
+          class="popup_button"
+          href="#"
+        >
+          <i
+            aria-hidden="true"
+            class="download icon"
+          />
+           
+          Download
+        </a>
+      </div>
+    </div>
+  </div>
+</body>
 `;
 
 exports[`Play Queue container should display with track in queue 1`] = `

--- a/packages/app/app/containers/PlayQueueContainer/__snapshots__/PlayQueueContainer.test.tsx.snap
+++ b/packages/app/app/containers/PlayQueueContainer/__snapshots__/PlayQueueContainer.test.tsx.snap
@@ -1,5 +1,248 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Play Queue container should display a context popup on right click 1`] = `
+<DocumentFragment>
+  <div
+    class="play_queue_container"
+  >
+    <div
+      class="queue_menu_container"
+    >
+      <div
+        class="queue_menu_buttons"
+      >
+        <a
+          class="compactButton"
+          href="#"
+        >
+          <i
+            aria-hidden="true"
+            class="angle right icon"
+          />
+        </a>
+        <div
+          aria-disabled="false"
+          aria-expanded="false"
+          class="ui item dropdown queue_menu_more"
+          role="listbox"
+          tabindex="0"
+        >
+          <i
+            aria-hidden="true"
+            class="ellipsis vertical icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              class="header"
+            >
+              Queue
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="trash icon"
+              />
+              Clear queue
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="save icon"
+              />
+              Save as playlist
+            </div>
+            <div
+              class="divider"
+            />
+            <div
+              class="header"
+            >
+              Current track
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <div
+                aria-expanded="false"
+                class="ui dropdown left"
+                role="listbox"
+                tabindex="0"
+              >
+                <div
+                  aria-atomic="true"
+                  aria-live="polite"
+                  class="divider text"
+                  role="alert"
+                >
+                  Add to playlist
+                </div>
+                <i
+                  aria-hidden="true"
+                  class="dropdown icon"
+                />
+                <div
+                  class="menu transition left playlists_menu"
+                />
+              </div>
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="star icon"
+              />
+              Add to favorites
+            </div>
+            <div
+              class="item"
+              role="option"
+            >
+              <i
+                aria-hidden="true"
+                class="download icon"
+              />
+              Download
+            </div>
+          </div>
+        </div>
+      </div>
+      <hr />
+    </div>
+    <div
+      class="play_queue_items fade_in"
+      data-rbd-droppable-context-id="1"
+      data-rbd-droppable-id="play_queue"
+    >
+      <div
+        aria-describedby="rbd-hidden-text-1-hidden-text-4"
+        data-rbd-drag-handle-context-id="1"
+        data-rbd-drag-handle-draggable-id="uuid1+0"
+        data-rbd-draggable-context-id="1"
+        data-rbd-draggable-id="uuid1+0"
+        draggable="false"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          data-testid="queue-popup-uuid1"
+        >
+          <div
+            class="nuclear queue_item current_song"
+          >
+            <div
+              class="thumbnail"
+            >
+              <img
+                src="https://test-track-thumb-url"
+              />
+              <div
+                class="thumbnail_overlay"
+              >
+                <i
+                  aria-hidden="true"
+                  class="trash alternate outline big icon"
+                />
+              </div>
+            </div>
+            <div
+              class="item_info_container"
+            >
+              <div
+                class="name_container"
+              >
+                test track 1
+              </div>
+              <div
+                class="artist_container"
+              >
+                BTS
+              </div>
+            </div>
+            <div
+              class="item_duration_container"
+            >
+              <div
+                class="item_duration"
+              >
+                05:00
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-describedby="rbd-hidden-text-1-hidden-text-4"
+        data-rbd-drag-handle-context-id="1"
+        data-rbd-drag-handle-draggable-id="uuid2+1"
+        data-rbd-draggable-context-id="1"
+        data-rbd-draggable-id="uuid2+1"
+        draggable="false"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          data-testid="queue-popup-uuid2"
+        >
+          <div
+            class="nuclear queue_item"
+          >
+            <div
+              class="thumbnail"
+            >
+              <img
+                src="https://test-track-thumb-url"
+              />
+              <div
+                class="thumbnail_overlay"
+              >
+                <i
+                  aria-hidden="true"
+                  class="trash alternate outline big icon"
+                />
+              </div>
+            </div>
+            <div
+              class="item_info_container"
+            >
+              <div
+                class="name_container"
+              >
+                test track 2
+              </div>
+              <div
+                class="artist_container"
+              >
+                BTS
+              </div>
+            </div>
+            <div
+              class="item_duration_container"
+            >
+              <div
+                class="item_duration"
+              >
+                00:00
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Play Queue container should display with track in queue 1`] = `
 <DocumentFragment>
   <div
@@ -175,7 +418,7 @@ exports[`Play Queue container should display with track in queue 1`] = `
               <div
                 class="item_duration"
               >
-                00:00
+                05:00
               </div>
             </div>
           </div>

--- a/packages/app/app/containers/QueuePopupContainer/index.js
+++ b/packages/app/app/containers/QueuePopupContainer/index.js
@@ -1,5 +1,7 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { clipboard } from 'electron';
+import { compose, withHandlers } from 'recompose';
 import * as QueueActions from '../../actions/queue';
 
 import QueuePopup from '../../components/PlayQueue/QueuePopup';
@@ -12,4 +14,13 @@ const mapDispatchToProps = dispatch => ({
   actions: bindActionCreators(Object.assign({}, QueueActions), dispatch)
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(QueuePopup);
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  withHandlers({
+    copyToClipboard: () => (text) => {
+      if (text?.length) {
+        clipboard.writeText(text);
+      }
+    }
+  })
+)(QueuePopup);

--- a/packages/app/test/storeBuilders.ts
+++ b/packages/app/test/storeBuilders.ts
@@ -450,7 +450,7 @@ export const buildStoreState = () => {
               'thumbnail': 'https://test-track-thumb-url',
               'streams': [
                 {
-                  'source': 'Youtube',
+                  'source': 'Test Stream Provider',
                   'id': 'CuklIb9d3fI',
                   'stream': 'https://test-track-stream-url',
                   'duration': 300,

--- a/packages/app/test/storeBuilders.ts
+++ b/packages/app/test/storeBuilders.ts
@@ -19,7 +19,11 @@ export const buildStoreState = () => {
       loading: false,
       error: false
     },
-    connectivity: false
+    connectivity: false,
+    queue: {
+      queueItems: [],
+      currentSong: 0
+    }
   };
 
   return {
@@ -431,6 +435,76 @@ export const buildStoreState = () => {
           loading: false,
           error: false
         }
+      };
+
+      return this as StoreStateBuilder;
+    },
+    withTrackInPlayQueue() {
+      state = {
+        ...state,
+        queue: {
+          queueItems: [
+            {
+              'artist': 'BTS',
+              'name': 'test track 1',
+              'thumbnail': 'https://test-track-thumb-url',
+              'streams': [
+                {
+                  'source': 'Youtube',
+                  'id': 'CuklIb9d3fI',
+                  'stream': 'https://test-track-stream-url',
+                  'duration': 300,
+                  'title': 'test track 1',
+                  'thumbnail': 'https://test-track-thumb-url',
+                  'format': 'webm',
+                  'skipSegments': [
+                    {
+                      'category': 'intro',
+                      'startTime': 0,
+                      'endTime': 5
+                    },
+                    {
+                      'category': 'music_offtopic',
+                      'startTime': 5,
+                      'endTime': 22
+                    },
+                    {
+                      'category': 'music_offtopic',
+                      'startTime': 239,
+                      'endTime': 299
+                    }
+                  ],
+                  'originalUrl': 'https://test-track-original-url'
+                }
+              ],
+              'uuid': 'uuid1',
+              'loading': false,
+              'error': false
+            },
+            {
+              'artist': 'BTS',
+              'name': 'test track 2',
+              'thumbnail': 'https://test-track-thumb-url',
+              'streams': [
+                {
+                  'source': 'Youtube',
+                  'id': 'CuklIb9d3fI',
+                  'stream': 'https://test-track-stream-url',
+                  'duration': 300,
+                  'title': 'test track 2',
+                  'thumbnail': 'https://test-track-thumb-url',
+                  'format': 'webm',
+                  'skipSegments': []
+                }
+              ],
+              'uuid': 'uuid2',
+              'loading': false,
+              'error': false
+            }
+          ],
+          currentSong: 0
+        }
+        
       };
 
       return this as StoreStateBuilder;

--- a/packages/app/test/testUtils.tsx
+++ b/packages/app/test/testUtils.tsx
@@ -74,7 +74,7 @@ export const setupI18Next = () => {
 };
 
 export const mountComponent = (
-  willMountComponent: React.ReactElement, 
+  componentToMount: React.ReactElement, 
   initialHistoryEntries: string[],
   initialStore?: AnyProps, 
   defaultInitialStore?: AnyProps) => {
@@ -91,7 +91,7 @@ export const mountComponent = (
       <TestStoreProvider
         store={store}
       >
-        {willMountComponent}
+        {componentToMount}
       </TestStoreProvider>
     </TestRouterProvider>
   );
@@ -133,9 +133,7 @@ export const mountedPlayQueueFactory= (
 ) =>
   (initialStore?: AnyProps) => {
     return mountComponent(
-      <body>
-        <PlayQueueContainer />
-      </body>, 
+      <PlayQueueContainer />, 
       initialHistoryEntries, 
       initialStore, 
       defaultInitialStore

--- a/packages/app/test/testUtils.tsx
+++ b/packages/app/test/testUtils.tsx
@@ -15,6 +15,7 @@ import { render } from '@testing-library/react';
 
 import MainContentContainer from '../app/containers/MainContentContainer';
 import HelpModalContainer from '../app/containers/HelpModalContainer';
+import PlayQueueContainer from '../app/containers/PlayQueueContainer';
 import Navbar from '../app/components/Navbar';
 import NavButtons from '../app/components/NavButtons';
 
@@ -120,6 +121,19 @@ export const mountedNavbarFactory= (
         <NavButtons />
         <HelpModalContainer />
       </Navbar>, 
+      initialHistoryEntries, 
+      initialStore, 
+      defaultInitialStore
+    );
+  };
+
+export const mountedPlayQueueFactory= (
+  initialHistoryEntries: string[],
+  defaultInitialStore?: AnyProps
+) =>
+  (initialStore?: AnyProps) => {
+    return mountComponent(
+      <PlayQueueContainer />, 
       initialHistoryEntries, 
       initialStore, 
       defaultInitialStore

--- a/packages/app/test/testUtils.tsx
+++ b/packages/app/test/testUtils.tsx
@@ -133,7 +133,9 @@ export const mountedPlayQueueFactory= (
 ) =>
   (initialStore?: AnyProps) => {
     return mountComponent(
-      <PlayQueueContainer />, 
+      <body>
+        <PlayQueueContainer />
+      </body>, 
       initialHistoryEntries, 
       initialStore, 
       defaultInitialStore

--- a/packages/app/test/testUtils.tsx
+++ b/packages/app/test/testUtils.tsx
@@ -77,7 +77,8 @@ export const mountComponent = (
   componentToMount: React.ReactElement, 
   initialHistoryEntries: string[],
   initialStore?: AnyProps, 
-  defaultInitialStore?: AnyProps) => {
+  defaultInitialStore?: AnyProps,
+  renderOptions?: {}) => {
   const initialState = initialStore || defaultInitialStore;
 
   const history = createMemoryHistory({
@@ -93,7 +94,7 @@ export const mountComponent = (
       >
         {componentToMount}
       </TestStoreProvider>
-    </TestRouterProvider>
+    </TestRouterProvider>, renderOptions
   );
   return { component, history, store };
 };
@@ -126,7 +127,7 @@ export const mountedNavbarFactory= (
       defaultInitialStore
     );
   };
-
+// { container: document.body }
 export const mountedPlayQueueFactory= (
   initialHistoryEntries: string[],
   defaultInitialStore?: AnyProps
@@ -136,6 +137,7 @@ export const mountedPlayQueueFactory= (
       <PlayQueueContainer />, 
       initialHistoryEntries, 
       initialStore, 
-      defaultInitialStore
+      defaultInitialStore,
+      { container: document.body }
     );
   };

--- a/packages/core/src/plugins/plugins.types.ts
+++ b/packages/core/src/plugins/plugins.types.ts
@@ -106,4 +106,7 @@ export type StreamData = {
     duration: number;
     title: string;
     thumbnail: string;
+    originalUrl?: string;
+    format?: string;
+    skipSegments?: Array<any>
 }

--- a/packages/core/src/plugins/stream/AudiusPlugin.ts
+++ b/packages/core/src/plugins/stream/AudiusPlugin.ts
@@ -11,6 +11,7 @@ class AudiusPlugin extends StreamProviderPlugin {
     this.name = 'Audius Plugin';
     this.sourceName = 'Audius';
     this.description = 'A plugin that adds Audius search and streaming support to Nuclear.';
+    this.baseUrl = 'https://audius.co';
     this.image = null;
     this.init();
   }
@@ -54,7 +55,8 @@ class AudiusPlugin extends StreamProviderPlugin {
       stream: `${this.apiEndpoint}/tracks/${result.id}/stream?app_name=Nuclear`,
       duration: result.duration,
       title: result.title,
-      thumbnail: result.artwork ? result.artwork['480x480'] : ''
+      thumbnail: result.artwork ? result.artwork['480x480'] : '',
+      originalUrl: `${this.baseUrl}${result.permalink}`
     };
   }
 }

--- a/packages/core/src/plugins/stream/BandcampPlugin.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.ts
@@ -1,6 +1,7 @@
 import { Bandcamp } from '../../rest';
 import { BandcampSearchResult } from '../../rest/Bandcamp';
 import { StreamQuery, StreamData } from '../plugins.types';
+import logger from 'electron-timber';
 import StreamProviderPlugin from '../streamProvider';
 
 class BandcampPlugin extends StreamProviderPlugin {
@@ -37,14 +38,21 @@ class BandcampPlugin extends StreamProviderPlugin {
       stream,
       duration,
       title: result.name,
-      thumbnail: result.imageUrl
+      thumbnail: result.imageUrl,
+      originalUrl: result.url
     };
   }
 
   async search(query: StreamQuery): Promise<void | StreamData> {
-    const track = await this.findTrackUrl(query);
-    const { stream, duration } = await Bandcamp.getTrackData(track.url);
-    return this.resultToStream(track, stream, duration);
+    try {
+      const track = await this.findTrackUrl(query);
+      const { stream, duration } = await Bandcamp.getTrackData(track.url);
+      return this.resultToStream(track, stream, duration);
+      
+    } catch (error) {
+      logger.error(`Error while searching  for ${query.artist + ' ' + query.track} on Bandcamp`);
+      logger.error(error);
+    }
   }
 
   async getAlternateStream(query: StreamQuery): Promise<void | StreamData> {

--- a/packages/core/src/plugins/stream/JamendoPlugin.ts
+++ b/packages/core/src/plugins/stream/JamendoPlugin.ts
@@ -1,6 +1,7 @@
 import logger from 'electron-timber';
 import _ from 'lodash';
 
+import { StreamQuery, StreamData } from '../plugins.types';
 import StreamProviderPlugin from '../streamProvider';
 import * as Jamendo from '../../rest/Jamendo';
 
@@ -13,21 +14,21 @@ class JamendoPlugin extends StreamProviderPlugin {
     this.image = null;
   }
 
-  search(query) {
+  search(query: StreamQuery): Promise<void | StreamData>  {
     return this.getSearchResults(query).then(responseJson => {
       if (responseJson.results.length === 0) {
         return null;
       }
 
       const track = responseJson.results[0].tracks[0];
-
       return {
         source: this.sourceName,
         id: track.id,
         stream: track.audio,
         duration: track.duration,
         title: track.name,
-        thumbnail: track.image
+        thumbnail: track.image,
+        originalUrl: track.audio
       };
     });
   }

--- a/packages/core/src/plugins/stream/SoundcloudPlugin.ts
+++ b/packages/core/src/plugins/stream/SoundcloudPlugin.ts
@@ -21,7 +21,8 @@ class SoundcloudPlugin extends StreamProviderPlugin {
       stream: result.stream_url + `?client_id=${process.env.SOUNDCLOUD_API_KEY}`,
       duration: result.duration/1000,
       title: result.title,
-      thumbnail: result.user.avatar_url
+      thumbnail: result.user.avatar_url,
+      originalUrl: result.permalink_url
     };
   }
 

--- a/packages/core/src/plugins/stream/YoutubePlugin.ts
+++ b/packages/core/src/plugins/stream/YoutubePlugin.ts
@@ -1,6 +1,6 @@
 import logger from 'electron-timber';
 
-import { StreamQuery } from '../plugins.types';
+import { StreamQuery, StreamData } from '../plugins.types';
 import StreamProviderPlugin from '../streamProvider';
 import * as Youtube from '../../rest/Youtube';
 class YoutubePlugin extends StreamProviderPlugin {
@@ -13,7 +13,7 @@ class YoutubePlugin extends StreamProviderPlugin {
     this.isDefault = true;
   }
 
-  async search(query: StreamQuery) {
+  async search(query: StreamQuery): Promise<void | StreamData> {
     const terms = query.artist + ' ' + query.track;
     try {
       return await Youtube.trackSearch(query, undefined, this.sourceName);
@@ -23,7 +23,7 @@ class YoutubePlugin extends StreamProviderPlugin {
     }
   }
 
-  async getAlternateStream(query: StreamQuery, currentStream: { id: string }) {
+  async getAlternateStream(query: StreamQuery, currentStream: { id: string }): Promise<void | StreamData> {
     const terms = query.artist + ' ' + query.track;
     try {
       return await Youtube.trackSearch(query, currentStream.id, this.sourceName);

--- a/packages/core/src/plugins/stream/iTunesPodcastPlugin.ts
+++ b/packages/core/src/plugins/stream/iTunesPodcastPlugin.ts
@@ -21,7 +21,8 @@ class iTunesPodcastPlugin extends StreamProviderPlugin {
       stream: result.episodeUrl,
       duration: result.trackTimeMillis / 1000,
       title: result.trackName,
-      thumbnail: result.artworkUrl600
+      thumbnail: result.artworkUrl600,
+      originalUrl: result.trackViewUrl
     };
   }
 
@@ -41,6 +42,7 @@ class iTunesPodcastPlugin extends StreamProviderPlugin {
     const podcast = query.artist;
     const episode = query.track;
     const podcastId = await this.findPodcastId(podcast);
+
     return iTunes.getPodcastEpisodes(podcastId, '50')
       .then(data => data.json())
       .then(results => {
@@ -58,6 +60,7 @@ class iTunesPodcastPlugin extends StreamProviderPlugin {
   async getAlternateStream(query: StreamQuery, currentStream: { id: string; }): Promise<void | StreamData> {
     const podcast = query.artist;
     const podcastId = await this.findPodcastId(podcast);
+
     return iTunes.getPodcastEpisodes(podcastId, '50')
       .then(data => data.json())
       .then(results => {

--- a/packages/core/src/plugins/streamProvider.ts
+++ b/packages/core/src/plugins/streamProvider.ts
@@ -8,6 +8,8 @@ abstract class StreamProviderPlugin extends Plugin {
   sourceName: string;
   apiEndpoint?: string;
 
+  baseUrl?: string;
+
   abstract search(query: StreamQuery): Promise<StreamData|void>;
   abstract getAlternateStream(query: StreamQuery, currentStream: { id: string }): Promise<StreamData|void>;
   getStreamForId?(id: string): Promise<StreamData['stream']>;

--- a/packages/core/src/rest/Invidious.ts
+++ b/packages/core/src/rest/Invidious.ts
@@ -1,7 +1,7 @@
 import { getOption } from '../persistence/store';
 import { StreamData } from '../plugins/plugins.types';
 
-const baseUrl = getOption('invidious.url');
+export const baseUrl = getOption('invidious.url');
 
 const getTrackInfo = async (videoId) => {
   const response = await fetch(`${baseUrl}/api/v1/videos/${videoId}`);

--- a/packages/core/src/rest/Youtube.ts
+++ b/packages/core/src/rest/Youtube.ts
@@ -6,7 +6,7 @@ import ytlist from 'youtube-playlist';
 import ytsr from 'ytsr';
 
 import LastFmApi from './Lastfm';
-import { StreamQuery } from '../plugins/plugins.types';
+import { StreamData, StreamQuery } from '../plugins/plugins.types';
 import * as SponsorBlock from './SponsorBlock';
 
 const lastfm = new LastFmApi(
@@ -137,7 +137,7 @@ export async function trackSearch(query: StreamQuery, omitStreamId?: string, sou
   return trackSearchByString(terms, omitStreamId, sourceName);
 }
 
-export async function trackSearchByString(query: string, omitStreamId?: string, sourceName?: string) {
+export async function trackSearchByString(query: string, omitStreamId?: string, sourceName?: string): Promise<StreamData> {
   const filterOptions = await ytsr.getFilters(query);
   const filterVideoOnly = filterOptions.get('Type').get('Video'); 
   const results = await ytsr(filterVideoOnly.url, { limit: omitStreamId ? 15 : 1 });
@@ -159,7 +159,8 @@ export async function trackSearchByString(query: string, omitStreamId?: string, 
       title: topTrackInfo.videoDetails.title,
       thumbnail: topTrack.bestThumbnail.url,
       format: formatInfo.container,
-      skipSegments: segments
+      skipSegments: segments,
+      originalUrl: topTrack.url
     };
   } catch (e){
     logger.error('youtube track search error');

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -170,6 +170,8 @@
     "header": "Queue",
     "header-track": "Current track",
     "id": "Stream ID:",
+    "source": "Source:",
+    "copy-track-url": "Copy track url to clipboard",
     "loading": "Stream still loading.",
     "playlist-add": "Add to playlist",
     "playlist-toast-content": "Playlist {{name}} has been created.",

--- a/packages/ui/lib/components/StreamInfo/index.js
+++ b/packages/ui/lib/components/StreamInfo/index.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import styles from './styles.scss';
 import artPlaceholder from '../../../resources/media/art_placeholder.png';
 import { withHandlers } from 'recompose';
+import Tooltip from '../Tooltip';
 
 const StreamInfo = ({
   selectedStream,
@@ -16,7 +17,9 @@ const StreamInfo = ({
   track,
   dropdownOptions,
   idLabel,
-  titleLabel
+  titleLabel,
+  copyTrackUrlLabel,
+  sourceLabel
 }) => {
   return (
     <div className={styles.stream_info}>
@@ -30,7 +33,7 @@ const StreamInfo = ({
       </div>
       <div className={styles.stream_text_info}>
         <div className={styles.stream_source}>
-          <label>Source:</label>{' '}
+          <label>{sourceLabel}</label>{' '}
           <Dropdown
             inline
             options={dropdownOptions}
@@ -54,9 +57,14 @@ const StreamInfo = ({
       </div>
       <div className={styles.stream_buttons}>
         {selectedStream.originalUrl && (
-          <a href='#' data-testid='copy-orignal-url' onClick={handleCopyStreamUrl}>
-            <Icon name='copy' />
-          </a>
+          <Tooltip
+            on='hover'
+            content={copyTrackUrlLabel}
+            trigger={<a href='#' data-testid='copy-orignal-url' onClick={handleCopyStreamUrl}>
+              <Icon name='linkify' />
+            </a>}
+          />
+          
         )}
         <a href='#' onClick={handleRerollTrack}>
           <Icon name='refresh' />
@@ -71,7 +79,9 @@ StreamInfo.propTypes = {
   track: PropTypes.object.isRequired,
   dropdownOptions: PropTypes.array,
   idLabel: PropTypes.string,
-  titleLabel: PropTypes.string
+  titleLabel: PropTypes.string,
+  copyTrackUrlLabel: PropTypes.string,
+  sourceLabel: PropTypes.string
 };
 
 export default withHandlers({

--- a/packages/ui/lib/components/StreamInfo/index.js
+++ b/packages/ui/lib/components/StreamInfo/index.js
@@ -13,7 +13,7 @@ const StreamInfo = ({
   handleRerollTrack,
   handleSelectStream,
   handleImageLoaded,
-  handleCopyStreamUrl,
+  handleCopyTrackUrl,
   track,
   dropdownOptions,
   idLabel,
@@ -60,7 +60,7 @@ const StreamInfo = ({
           <Tooltip
             on='hover'
             content={copyTrackUrlLabel}
-            trigger={<a href='#' data-testid='copy-orignal-url' onClick={handleCopyStreamUrl}>
+            trigger={<a href='#' data-testid='copy-orignal-url' onClick={handleCopyTrackUrl}>
               <Icon name='linkify' />
             </a>}
           />
@@ -96,7 +96,7 @@ export default withHandlers({
   handleImageLoaded: ({ onImageLoaded }) => () => {
     onImageLoaded();
   },
-  handleCopyStreamUrl: ({ onCopyStreamUrl }) => () => {
-    onCopyStreamUrl();
+  handleCopyTrackUrl: ({ onCopyTrackUrl }) => () => {
+    onCopyTrackUrl();
   }
 })(StreamInfo);

--- a/packages/ui/lib/components/StreamInfo/index.js
+++ b/packages/ui/lib/components/StreamInfo/index.js
@@ -12,6 +12,7 @@ const StreamInfo = ({
   handleRerollTrack,
   handleSelectStream,
   handleImageLoaded,
+  handleCopyStreamUrl,
   track,
   dropdownOptions,
   idLabel,
@@ -52,6 +53,11 @@ const StreamInfo = ({
         )}
       </div>
       <div className={styles.stream_buttons}>
+        {selectedStream.originalUrl && (
+          <a href='#' data-testid='copy-orignal-url' onClick={handleCopyStreamUrl}>
+            <Icon name='copy' />
+          </a>
+        )}
         <a href='#' onClick={handleRerollTrack}>
           <Icon name='refresh' />
         </a>
@@ -79,5 +85,8 @@ export default withHandlers({
   },
   handleImageLoaded: ({ onImageLoaded }) => () => {
     onImageLoaded();
+  },
+  handleCopyStreamUrl: ({ onCopyStreamUrl }) => () => {
+    onCopyStreamUrl();
   }
 })(StreamInfo);

--- a/packages/ui/lib/components/StreamInfo/index.js
+++ b/packages/ui/lib/components/StreamInfo/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Img from 'react-image';
 import { Dropdown, Icon } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
+import _ from 'lodash';
 
 import styles from './styles.scss';
 import artPlaceholder from '../../../resources/media/art_placeholder.png';
@@ -60,7 +61,7 @@ const StreamInfo = ({
           <Tooltip
             on='hover'
             content={copyTrackUrlLabel}
-            trigger={<a href='#' data-testid='copy-orignal-url' onClick={handleCopyTrackUrl}>
+            trigger={<a href='#' data-testid='copy-original-url' onClick={handleCopyTrackUrl}>
               <Icon name='linkify' />
             </a>}
           />

--- a/packages/ui/lib/components/StreamInfo/styles.scss
+++ b/packages/ui/lib/components/StreamInfo/styles.scss
@@ -78,7 +78,6 @@
     bottom: 0;
     width: 100%;
     display: flex;
-    flex-flow: column;
     justify-content: flex-end;
     align-items: flex-end;
     padding: 0.5rem;


### PR DESCRIPTION
It copy the track page url to clipboard (based on stream provider), not the stream url

<img width="294" alt="image" src="https://user-images.githubusercontent.com/12780733/127730645-74835e35-6430-4ef8-a107-6a028ce949a1.png">
