### PR TITLE
Fix MPRIS for flatpak

### DIFF
--- a/packages/main/src/services/@linux/system-api.ts
+++ b/packages/main/src/services/@linux/system-api.ts
@@ -48,7 +48,7 @@ class LinuxMediaService extends MprisService implements NuclearApi {
     @inject(Window) private window: Window
   ) {
     super({
-      name: config.title.replace(/ /g, '_'),
+      name: config.appid,
       identity: config.title,
       supportedMimeTypes: config.supportedFormats.map(format => `audio/${format}`),
       supportedUriSchemes: ['file', 'uri'],

--- a/packages/main/src/services/config/index.ts
+++ b/packages/main/src/services/config/index.ts
@@ -19,6 +19,7 @@ class Config {
   youtubeUrl: string;
   youtubeSearch: string;
   title: string;
+  appid: string;
   supportedFormats: string[];
   env: Env;
   icon: string;
@@ -33,6 +34,7 @@ class Config {
   ) {
     this.env = process.env.NODE_ENV as Env || Env.DEV;
     this.title = 'Nuclear Music Player';
+    this.appid = 'org.js.nuclear.Nuclear';
     this.youtubeUrl = 'https://www.youtube.com/watch';
     this.youtubeSearch = 'https://www.googleapis.com/youtube/v3/search?part=id,snippet&type=video&maxResults=50&q=';
     this.supportedFormats = _.uniq(pkg.build.fileAssociations.map(({ ext }) => ext));


### PR DESCRIPTION
Untested because I can't be arsed to build this thing. The problem is that the MPRIS bus for an app should be org.mpris.MediaPlayer2.$APPID so in this case org.mpris.MediaPlayer2.org.js.nuclear.Nuclear but it is org.mpris.MediaPlayer2.Nuclear_Music_Player. Flatpak enforces the bus naming so it doesn't show up outside the sandbox.

As a workaround one can override the flatpak permissions so that nuclear can own the bus name org.mpris.MediaPlayer2.Nuclear_Music_Player on the session bus.