### PR TITLE
Fix: Drop down menu on right side of search bar gets hidden

### DIFF
--- a/packages/ui/lib/components/SearchBox/styles.scss
+++ b/packages/ui/lib/components/SearchBox/styles.scss
@@ -60,7 +60,7 @@ $input_height: 30px;
       justify-content: space-between;
       align-items: center;
       padding: 0 12px;
-
+      z-index: 10000;
       color: $white;
       background: $blue;
 


### PR DESCRIPTION
Plugin dropdown on right of search bar now appears over the search drop down

#1050

Test result log (successful):
[overlay_output.txt](https://github.com/nukeop/nuclear/files/7149332/overlay_output.txt)
