### PR TITLE
Add duration property to /nuclear/player/now-playing

### DIFF
--- a/packages/app/app/containers/IpcContainer/index.js
+++ b/packages/app/app/containers/IpcContainer/index.js
@@ -98,8 +98,9 @@ class IpcContainer extends React.Component {
 
       try {
         const { artist, name, thumbnail } = this.props.queue.queueItems[this.props.queue.currentSong];
+        const duration = this.props.queue.queueItems[this.props.queue.currentSong].streams?.[0]?.duration;
 
-        ipcRenderer.send(IpcEvents.PLAYING_STATUS, { ...this.props.player, artist, name, thumbnail, loopAfterQueueEnd, shuffleQueue });
+        ipcRenderer.send(IpcEvents.PLAYING_STATUS, { ...this.props.player, artist, name, thumbnail, loopAfterQueueEnd, shuffleQueue, duration });
       } catch (err) {
         ipcRenderer.send(IpcEvents.PLAYING_STATUS, { ...this.props.player, loopAfterQueueEnd, shuffleQueue });
       }


### PR DESCRIPTION
Add duration property to /nuclear/player/now-playing

Fixes #1214

There doesn't appear to be any existing tests for the REST API so I didn't bother creating one