### PR TITLE
Searchbox HOC -> Hooks & Proptypes -> Typescript

### DIFF
--- a/packages/app/app/containers/SearchBoxContainer/__snapshots__/SearchBoxContainer.test.tsx.snap
+++ b/packages/app/app/containers/SearchBoxContainer/__snapshots__/SearchBoxContainer.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Search box container should render the search box 1`] = `
         class=""
         data-testid="search-input"
         placeholder="Search..."
+        value=""
       />
       <div
         aria-disabled="false"

--- a/packages/app/app/containers/SearchBoxContainer/index.tsx
+++ b/packages/app/app/containers/SearchBoxContainer/index.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import _ from 'lodash';
+import React, { useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
@@ -47,25 +46,6 @@ const SearchBoxContainer: React.FC = () => {
     provider && dispatch(selectMetaProvider(provider.value)),
   [dispatch]);
 
-  const [input, setInput] = useState('');
- 
-  const debouncedSearch = useCallback(_.debounce(handleSearch, 500), [handleSearch]);
-
-  useEffect(() => {
-    if (input.length > MIN_SEARCH_LENGTH) {
-      debouncedSearch(input);
-    }
-  }, [input, debouncedSearch]);
-
-  
-  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      handleSearch(input);
-    }
-    if (e.key === 'Escape') {
-      handleFocus(false);
-    }
-  };
 
   return <SearchBox 
     loading={unifiedSearchStarted}
@@ -82,9 +62,7 @@ const SearchBoxContainer: React.FC = () => {
     onSearchProviderSelect={handleSelectSearchProvider}
     isFocused={isFocused}
     handleFocus={handleFocus}
-    onKeyDown={onKeyDown}
-    input={input}
-    setInput={setInput}
+    minSearchLength={MIN_SEARCH_LENGTH}
   />;
 };
 

--- a/packages/app/app/containers/SearchBoxContainer/index.tsx
+++ b/packages/app/app/containers/SearchBoxContainer/index.tsx
@@ -1,11 +1,10 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import _ from 'lodash';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { MetaProvider } from '@nuclear/core';
 import { SearchBox } from '@nuclear/ui';
-
 import { SearchActions, unifiedSearch } from '../../actions/search';
 import { pluginsSelectors } from '../../selectors/plugins';
 import { searchSelectors } from '../../selectors/search';
@@ -48,6 +47,26 @@ const SearchBoxContainer: React.FC = () => {
     provider && dispatch(selectMetaProvider(provider.value)),
   [dispatch]);
 
+  const [input, setInput] = useState('');
+ 
+  const debouncedSearch = useCallback(_.debounce(handleSearch, 500), [handleSearch]);
+
+  useEffect(() => {
+    if (input.length > MIN_SEARCH_LENGTH) {
+      debouncedSearch(input);
+    }
+  }, [input, debouncedSearch]);
+
+  
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch(input);
+    }
+    if (e.key === 'Escape') {
+      handleFocus(false);
+    }
+  };
+
   return <SearchBox 
     loading={unifiedSearchStarted}
     disabled={!isConnected}
@@ -55,7 +74,6 @@ const SearchBoxContainer: React.FC = () => {
     lastSearchesLabel={t('last-searches')}
     clearHistoryLabel={t('clear-history')}
     footerLabel={t('you-can-search-for')}
-    onChange={_.debounce(handleSearch, 500)}
     onSearch={handleSearch}
     searchProviders={searchProvidersOptions}
     searchHistory={searchHistory}
@@ -64,6 +82,9 @@ const SearchBoxContainer: React.FC = () => {
     onSearchProviderSelect={handleSelectSearchProvider}
     isFocused={isFocused}
     handleFocus={handleFocus}
+    onKeyDown={onKeyDown}
+    input={input}
+    setInput={setInput}
   />;
 };
 

--- a/packages/ui/lib/components/SearchBox/index.tsx
+++ b/packages/ui/lib/components/SearchBox/index.tsx
@@ -1,15 +1,34 @@
 import React, { useEffect, useRef } from 'react';
-import PropTypes from 'prop-types';
 import cx from 'classnames';
 import _ from 'lodash';
 import { Dropdown, Icon } from 'semantic-ui-react';
-import { compose, withHandlers, withState } from 'recompose';
 import SearchBoxDropdown from '../SearchBoxDropbown';
-
 import common from '../../common.scss';
 import styles from './styles.scss';
+import { SearchProviderOption } from '../../types';
 
-const SearchBox = ({
+
+type SearchBarProps = {
+  loading: boolean
+  disabled: boolean
+  placeholder: string 
+  searchProviders: SearchProviderOption[]
+  searchHistory: string[]
+  lastSearchesLabel: string
+  clearHistoryLabel: string
+  footerLabel: string
+  onClearHistory: React.MouseEventHandler;
+  onSearch: (entry: string) => void
+  selectedSearchProvider: SearchProviderOption
+  onSearchProviderSelect: (provider: SearchProviderOption) => void
+  onKeyDown: React.KeyboardEventHandler<HTMLInputElement>
+  handleFocus: (bool: boolean) => void
+  isFocused: boolean
+  input: string
+  setInput: (v: string) => void
+}
+
+const SearchBox: React.FC<SearchBarProps> = ({
   loading,
   disabled,
   placeholder,
@@ -22,16 +41,15 @@ const SearchBox = ({
   onSearch,
   selectedSearchProvider,
   onSearchProviderSelect,
-  onChange,
   onKeyDown,
   handleFocus,
   isFocused,
-  onClick
+  input,
+  setInput
 }) => {
-
   const searchRef = useRef(null);
   useEffect(() => {
-    const handleClick = e => {
+    const handleClick = (e: MouseEvent) => {
       if (searchRef.current && !searchRef.current.contains(e.target)) {
         handleFocus(false);
       }
@@ -57,18 +75,19 @@ const SearchBox = ({
           data-testid='search-input'
           autoFocus
           placeholder={placeholder}
-          onChange={onChange}
+          onChange={(e) => setInput(e.target.value)}
           onKeyDown={onKeyDown}
           disabled={disabled}
           className={cx({ [styles.disabled]: disabled })}
-          onClick={onClick}
+          onClick={() => handleFocus(true)}
+          value={input}
         />
         {loading && <Icon name='spinner' loading />}
         {
           !_.isNil(searchProviders) && !_.isEmpty(searchProviders) &&
           <Dropdown
             value={selectedSearchProvider.value}
-            onChange={onSearchProviderSelect}
+            onChange={(__, data) =>  onSearchProviderSelect(_.find(searchProviders, (opt) => opt.value === data.value))}
             options={searchProviders}
             disabled={disabled}
           />
@@ -89,50 +108,4 @@ const SearchBox = ({
   );
 };
 
-const optionShape = PropTypes.shape({
-  key: PropTypes.string,
-  text: PropTypes.string,
-  value: PropTypes.string
-});
-
-SearchBox.propTypes = {
-  loading: PropTypes.bool,
-  disabled: PropTypes.bool,
-  placeholder: PropTypes.string,
-  searchProviders: PropTypes.arrayOf(optionShape),
-  selectedSearchProvider: optionShape,
-  onSearchProviderSelect: PropTypes.func,
-  onChange: PropTypes.func,
-
-  /* eslint-disable react/no-unused-prop-types */
-  onSearch: PropTypes.func,
-  setTerms: PropTypes.func,
-  terms: PropTypes.string,
-  /* eslint-enable react/no-unused-prop-types */
-  handleFocus: PropTypes.func
-};
-
-const RETURN_KEYCODE = 13;
-const ESC_KEYCODE = 27;
-export default compose(
-  withState('terms', 'setTerms', ''),
-  withHandlers({
-    onSearchProviderSelect:
-      ({ searchProviders, onSearchProviderSelect }) =>
-        (e, { value }) =>
-          onSearchProviderSelect(_.find(searchProviders, { value })),
-    onChange: ({ onChange, setTerms }) => e => {
-      setTerms(e.target.value);
-      onChange(e.target.value);
-    },
-    onKeyDown: ({ onSearch, terms, handleFocus }) => e => {
-      if (e.which === RETURN_KEYCODE) {
-        onSearch(terms);
-      }
-      if (e.which === ESC_KEYCODE) {
-        handleFocus(false);
-      }
-    },
-    onClick: ({ handleFocus }) => () => handleFocus(true)
-  })
-)(SearchBox);
+export default SearchBox;

--- a/packages/ui/lib/components/SearchBox/index.tsx
+++ b/packages/ui/lib/components/SearchBox/index.tsx
@@ -63,7 +63,6 @@ const SearchBox: React.FC<SearchBarProps> = ({
   const debouncedSearch = useCallback(_.debounce(onSearch, 500), [onSearch]);
 
   useEffect(() => {
-    debouncedSearch.cancel();
     if (input.length > minSearchLength) {
       debouncedSearch(input);
     }

--- a/packages/ui/lib/components/SearchBox/index.tsx
+++ b/packages/ui/lib/components/SearchBox/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import cx from 'classnames';
 import _ from 'lodash';
 import { Dropdown, Icon } from 'semantic-ui-react';
@@ -21,11 +21,9 @@ type SearchBarProps = {
   onSearch: (entry: string) => void
   selectedSearchProvider: SearchProviderOption
   onSearchProviderSelect: (provider: SearchProviderOption) => void
-  onKeyDown: React.KeyboardEventHandler<HTMLInputElement>
   handleFocus: (bool: boolean) => void
   isFocused: boolean
-  input: string
-  setInput: (v: string) => void
+  minSearchLength: number
 }
 
 const SearchBox: React.FC<SearchBarProps> = ({
@@ -41,11 +39,10 @@ const SearchBox: React.FC<SearchBarProps> = ({
   onSearch,
   selectedSearchProvider,
   onSearchProviderSelect,
-  onKeyDown,
   handleFocus,
   isFocused,
-  input,
-  setInput
+  minSearchLength
+  
 }) => {
   const searchRef = useRef(null);
   useEffect(() => {
@@ -60,9 +57,30 @@ const SearchBox: React.FC<SearchBarProps> = ({
     }
   }, [handleFocus, isFocused, searchRef]);
 
+
+  const [input, setInput] = useState('');
+ 
+  const debouncedSearch = useCallback(_.debounce(onSearch, 500), [onSearch]);
+
+  useEffect(() => {
+    debouncedSearch.cancel();
+    if (input.length > minSearchLength) {
+      debouncedSearch(input);
+    }
+  }, [input, debouncedSearch]);
+
+  
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      onSearch(input);
+    }
+    if (e.key === 'Escape') {
+      handleFocus(false);
+    }
+  };
+
   return (
     <div className={cx(common.nuclear, styles.search_box_container)}>
-
       <div
         className={cx(
           common.nuclear,

--- a/packages/ui/lib/types.ts
+++ b/packages/ui/lib/types.ts
@@ -46,3 +46,9 @@ export type TrackStream = {
   thumbnail?: string;
   stream?: string;
 };
+
+export type SearchProviderOption = {
+  key: string
+  text: string
+  value: string
+}

--- a/packages/ui/stories/components/searchbox.stories.tsx
+++ b/packages/ui/stories/components/searchbox.stories.tsx
@@ -20,7 +20,7 @@ storiesOf('Components/Search box', module)
       <SearchBox 
         {...commonProps} 
         selectedSearchProvider={selectedSearchProvider}
-        onSearchProviderSelect={onSearchProviderSelect}
+        onSearchProviderSelect={(_, data) => onSearchProviderSelect(searchProviders.find((provider) => provider.value === data.value))}
       />
     </div>;
   })
@@ -29,7 +29,7 @@ storiesOf('Components/Search box', module)
     return <div className='bg'><SearchBox 
       {...commonProps} 
       selectedSearchProvider={selectedSearchProvider}
-      onSearchProviderSelect={onSearchProviderSelect}
+      onSearchProviderSelect={(_, data) => onSearchProviderSelect(searchProviders.find((provider) => provider.value === data.value))}
       loading
     />
     </div>;
@@ -39,7 +39,7 @@ storiesOf('Components/Search box', module)
     return <div className='bg'><SearchBox 
       {...commonProps} 
       selectedSearchProvider={selectedSearchProvider}
-      onSearchProviderSelect={onSearchProviderSelect}
+      onSearchProviderSelect={(_, data) => onSearchProviderSelect(searchProviders.find((provider) => provider.value === data.value))}
       disabled
     />
     </div>;


### PR DESCRIPTION
### Changes

Changed proptypes to typescript type.

Moved compose functions to hooks with minor refactor. 

Kept UI related state in component, assuming containers act more as a DAO to redux and other services.

Changed deprecated e.which to e.key

Changed the input to be controlled (using value) since we already have the required variables and it will make things like clearing or appending to the input easier. E.g. [#1241](https://github.com/nukeop/nuclear/issues/1241).

Changed storybook to typescript and updated snapshot

### UX improvement ideas from development / debugging

Search on input is a cool feature, but the debounce on the search is causing me some issues. On the installed version, when deleting input with backspace, multiple searches will fire and cause clutter in the search history, this worsens the longer the search entry is. 

**Proposed fix:**  Cancel previous debounced requests on input and increase debounce value to 750 ms.

When clicking on a search history entry it is not appended to the search bar, but will fire a search.

**Proposed fix:** Set the search history text to the input bar on click, to make it easier to reason with the search and edit to fit needs. 

This is my first contribution to an open source project, any constructive criticism is appreciated :)