### PR TITLE
Enhancement/1241

### DIFF
--- a/packages/app/app/containers/SearchBoxContainer/index.tsx
+++ b/packages/app/app/containers/SearchBoxContainer/index.tsx
@@ -35,10 +35,13 @@ const SearchBoxContainer: React.FC = () => {
     searchProviders?.find(provider => provider.sourceName === selectedSearchProvider)
   );
 
-  const handleSearch = useCallback(value =>
-    value.length >= MIN_SEARCH_LENGTH
-      ? dispatch(unifiedSearch(value, history))
-      : null,
+  const handleSearch = useCallback((value: string) => {
+    if (value.length >= MIN_SEARCH_LENGTH) {
+      handleFocus(false);
+      return dispatch(unifiedSearch(value, history));
+    }
+    return null;
+  },
   [dispatch, history]
   );
   const handleClearSearchHistory = useCallback(() => dispatch(SearchActions.updateSearchHistory([])), [dispatch]);
@@ -62,7 +65,6 @@ const SearchBoxContainer: React.FC = () => {
     onSearchProviderSelect={handleSelectSearchProvider}
     isFocused={isFocused}
     handleFocus={handleFocus}
-    minSearchLength={MIN_SEARCH_LENGTH}
   />;
 };
 

--- a/packages/ui/lib/components/SearchBox/index.tsx
+++ b/packages/ui/lib/components/SearchBox/index.tsx
@@ -72,6 +72,7 @@ const SearchBox: React.FC<SearchBarProps> = ({
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       onSearch(input);
+      handleFocus(false);
     }
     if (e.key === 'Escape') {
       handleFocus(false);
@@ -96,8 +97,8 @@ const SearchBox: React.FC<SearchBarProps> = ({
           onKeyDown={onKeyDown}
           disabled={disabled}
           className={cx({ [styles.disabled]: disabled })}
-          onClick={() => handleFocus(true)}
-          value={input}
+          onClick={() => handleFocus(true)}    
+          value={input}  
         />
         {loading && <Icon name='spinner' loading />}
         {

--- a/packages/ui/lib/components/SearchBox/index.tsx
+++ b/packages/ui/lib/components/SearchBox/index.tsx
@@ -97,8 +97,8 @@ const SearchBox: React.FC<SearchBarProps> = ({
           onKeyDown={onKeyDown}
           disabled={disabled}
           className={cx({ [styles.disabled]: disabled })}
-          onClick={() => handleFocus(true)}    
-          value={input}  
+          onClick={() => handleFocus(true)}
+          value={input}
         />
         {loading && <Icon name='spinner' loading />}
         {

--- a/packages/ui/lib/components/SearchBox/index.tsx
+++ b/packages/ui/lib/components/SearchBox/index.tsx
@@ -23,7 +23,6 @@ type SearchBarProps = {
   onSearchProviderSelect: (provider: SearchProviderOption) => void
   handleFocus: (bool: boolean) => void
   isFocused: boolean
-  minSearchLength: number
 }
 
 const SearchBox: React.FC<SearchBarProps> = ({
@@ -40,9 +39,7 @@ const SearchBox: React.FC<SearchBarProps> = ({
   selectedSearchProvider,
   onSearchProviderSelect,
   handleFocus,
-  isFocused,
-  minSearchLength
-  
+  isFocused
 }) => {
   const searchRef = useRef(null);
   useEffect(() => {
@@ -57,22 +54,17 @@ const SearchBox: React.FC<SearchBarProps> = ({
     }
   }, [handleFocus, isFocused, searchRef]);
 
-
   const [input, setInput] = useState('');
  
-  const debouncedSearch = useCallback(_.debounce(onSearch, 500), [onSearch]);
+  const debouncedSearch = useCallback(_.debounce(onSearch, 750), [onSearch]);
 
   useEffect(() => {
-    if (input.length > minSearchLength) {
-      debouncedSearch(input);
-    }
+    debouncedSearch(input);
   }, [input, debouncedSearch]);
-
   
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       onSearch(input);
-      handleFocus(false);
     }
     if (e.key === 'Escape') {
       handleFocus(false);


### PR DESCRIPTION
### Changes
Hides the history tab when enter is pressed to search. Issue: #1241 

If we want to extend this behavior to happen on every search (Not sure if this was intended by the comment in the issue)
We could move this logic to the handleSearch function in the container.