### PR TITLE
Fix for #1255

### DIFF
--- a/packages/app/app/containers/IpcContainer/index.js
+++ b/packages/app/app/containers/IpcContainer/index.js
@@ -55,7 +55,7 @@ class IpcContainer extends React.Component {
 
     ipcRenderer.on(IpcEvents.LOCAL_FILES, (event, data) => actions.scanLocalFoldersSuccess(data));
     ipcRenderer.on(IpcEvents.LOCAL_FILES_PROGRESS, (event, { scanProgress, scanTotal }) => actions.scanLocalFoldersProgress(scanProgress, scanTotal));
-    ipcRenderer.on(IpcEvents.LOCAL_FILES_ERROR, (event, err) => actions.scanLocalFoldersFailed(err));
+    ipcRenderer.on(IpcEvents.LOCAL_FILES_ERROR, (event, err) => actions.scanLocalFoldersFailure(err));
     ipcRenderer.on(IpcEvents.PLAY_STARTUP_TRACK, (event, meta) => {
       this.props.actions.playTrack([], meta);
       this.props.history.push('/library');

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -42,7 +42,7 @@
     "inversify": "^5.0.1",
     "jimp": "^0.16.1",
     "lodash": "^4.17.15",
-    "music-metadata": "^5.1.1",
+    "music-metadata": "^7.12.3",
     "node-fetch": "^2.6.0",
     "reflect-metadata": "^0.1.13",
     "rotating-file-stream": "^2.0.2",


### PR DESCRIPTION
### Changes

Update version for the music-metadata package.

Fix infinite loading on error, by using correct error handler

Fixes #1255 
