### PR TITLE
bound media shortcuts (play/pause,next/prev)

### DIFF
--- a/packages/app/app/containers/ShortcutsContainer/index.js
+++ b/packages/app/app/containers/ShortcutsContainer/index.js
@@ -114,6 +114,14 @@ class Shortcuts extends React.Component {
 
 
   componentDidMount() {
+    Mousetrap.addKeycodes({
+      179: 'MediaPlayPause',
+      177: 'MediaTrackPrevious',
+      176: 'MediaTrackNext'
+
+
+    });
+
     Mousetrap.bind('space', this.handleSpaceBar);
     Mousetrap.bind('enter', this.playCurrentSong);
     Mousetrap.bind('up', this.increaseVolume);
@@ -126,6 +134,9 @@ class Shortcuts extends React.Component {
     Mousetrap.bind(['ctrl+left', 'command+left'], this.props.actions.previousSong);
     Mousetrap.bind(['ctrl+top', 'command+top'], this.props.actions.unmute);
     Mousetrap.bind(['ctrl+down', 'command+down'], this.props.actions.mute);
+    Mousetrap.bind('MediaPlayPause',  this.handleSpaceBar);
+    Mousetrap.bind('MediaTrackPrevious',  this.props.actions.previousSong);
+    Mousetrap.bind('MediaTrackNext',  this.props.actions.nextSong);
   }
 
   componentWillUnmount() {
@@ -147,7 +158,12 @@ class Shortcuts extends React.Component {
       'ctrl+down',
       'command+down',
       'f12',
-      'command+i'
+      'command+i',
+      'MediaPlayPause',
+      'MediaTrackPrevious',
+      'MediaTrackNext'
+
+
     ]);
   }
 


### PR DESCRIPTION
In response to feature request : [Add listener for media play pause #1306](https://github.com/nukeop/nuclear/issues/1306)
Added Javascript keycodes  (https://www.toptal.com/developers/keycode) for media interaction buttons. Bound new keycodes to their appropriate commands.
![mtkc](https://user-images.githubusercontent.com/90010906/191602662-c7e5cfe1-08e0-4d52-a18c-617e34ee56a8.JPG)

![keycodes](https://user-images.githubusercontent.com/90010906/191601547-a826a494-4dac-4956-b573-ed01a4214fdc.JPG)




<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->
