### PR TITLE
Toggle Tray Icon

### DIFF
--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -133,6 +133,13 @@ export const settingsConfig: Array<Setting> = [
     default: true
   },
   {
+    name: 'showTrayIcon',
+    category: 'program-settings',
+    type: SettingType.BOOLEAN,
+    prettyName: 'show-tray-icon',
+    default: true
+  },
+  {
     name: 'miniPlayer',
     category: 'display',
     type: SettingType.BOOLEAN,

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -69,7 +69,9 @@ app.on('ready', async () => {
     await localLibraryDb.connect();
     container.listen();
     await window.load();
-    trayMenu.init();
+    if (store.getOption('showTrayIcon')) {
+      trayMenu.init();
+    }
     touchbarMenu.init();
     if (store.getOption('discordRichPresence')) {
       discord.init();

--- a/packages/main/src/services/trayMenu/index.ts
+++ b/packages/main/src/services/trayMenu/index.ts
@@ -60,7 +60,7 @@ class TrayMenu {
         enabled: false
       });
     }
-    
+
     template.push({
       type: 'separator'
     });
@@ -136,12 +136,14 @@ class TrayMenu {
   }
 
   update(newPlayerContext?: PlayerContext) {
-    if (newPlayerContext) {
-      this.setPlayerContext(newPlayerContext);
-    }
+    if (this.tray) {
+      if (newPlayerContext) {
+        this.setPlayerContext(newPlayerContext);
+      }
 
-    this.tray.setContextMenu(this.getMenu());
-    this.tray.setToolTip(this.getToolTipString());
+      this.tray.setContextMenu(this.getMenu());
+      this.tray.setToolTip(this.getToolTipString());
+    }
   }
 }
 


### PR DESCRIPTION
Added a setting to toggle the tray menu on startup. Requires rebooting for right now. Currently, if t he setting is toggled off, the traymenu simply isn't initialized. To deal with the issues that creates, updates don't work if the traymenu is undefined.

<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->
