### PR TITLE
Update sqlite3 package to fix npm install error on macOS with Apple Silicon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -156,7 +156,7 @@
 				"search-azlyrics": "0.0.3",
 				"semantic-ui-css": "^2.4.1",
 				"semantic-ui-react": "^2.0.4",
-				"sqlite3": "^5.0.3",
+				"sqlite3": "^5.1.2",
 				"stream-filter": "^2.1.0",
 				"stream-reduce": "^1.0.3",
 				"style-loader": "^2.0.0",
@@ -38420,9 +38420,9 @@
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
 		},
 		"node_modules/sqlite3": {
-			"version": "5.0.11",
-			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.11.tgz",
-			"integrity": "sha512-4akFOr7u9lJEeAWLJxmwiV43DJcGV7w3ab7SjQFAFaTVyknY3rZjvXTKIVtWqUoY4xwhjwoHKYs2HDW2SoHVsA==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.2.tgz",
+			"integrity": "sha512-D0Reg6pRWAFXFUnZKsszCI67tthFD8fGPewRddDCX6w4cYwz3MbvuwRICbL+YQjBAh9zbw+lJ/V9oC8nG5j6eg==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@mapbox/node-pre-gyp": "^1.0.0",
@@ -73588,9 +73588,9 @@
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
 		},
 		"sqlite3": {
-			"version": "5.0.11",
-			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.11.tgz",
-			"integrity": "sha512-4akFOr7u9lJEeAWLJxmwiV43DJcGV7w3ab7SjQFAFaTVyknY3rZjvXTKIVtWqUoY4xwhjwoHKYs2HDW2SoHVsA==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.2.tgz",
+			"integrity": "sha512-D0Reg6pRWAFXFUnZKsszCI67tthFD8fGPewRddDCX6w4cYwz3MbvuwRICbL+YQjBAh9zbw+lJ/V9oC8nG5j6eg==",
 			"requires": {
 				"@mapbox/node-pre-gyp": "^1.0.0",
 				"node-addon-api": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -209,6 +209,6 @@
   },
   "dependencies": {
     "node-gyp": "^9.0.0",
-    "sqlite3": "^5.0.3"
+    "sqlite3": "^5.1.2"
   }
 }

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -46,7 +46,7 @@
     "node-fetch": "^2.6.0",
     "reflect-metadata": "^0.1.13",
     "rotating-file-stream": "^2.0.2",
-    "sqlite3": "^5.0.3",
+    "sqlite3": "^5.1.2",
     "stream-filter": "^2.1.0",
     "stream-reduce": "^1.0.3",
     "swagger-spec-express": "^2.0.20",


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->

Update the version of sqlite3 from 5.0.11 to 5.1.2 where they added ARM64 binaries for Darwin so that this error doesn't occur:

```
> sqlite3@5.0.11 install /Users/username/Sources/nuclear/node_modules/sqlite3
> node-pre-gyp install --fallback-to-build

node-pre-gyp ERR! install response status 404 Not Found on https://github.com/TryGhost/node-sqlite3/releases/download/v5.0.11/napi-v6-darwin-unknown-arm64.tar.gz
node-pre-gyp WARN Pre-built binaries not installable for sqlite3@5.0.11 and node@14.20.1 (node-v83 ABI, unknown) (falling back to source compile with node-gyp)
node-pre-gyp WARN Hit error response status 404 Not Found on https://github.com/TryGhost/node-sqlite3/releases/download/v5.0.11/napi-v6-darwin-unknown-arm64.tar.gz
```