### PR TITLE
Look for the "verified" badge when looking for streams on youtube

### DIFF
--- a/packages/core/src/rest/heuristics.ts
+++ b/packages/core/src/rest/heuristics.ts
@@ -67,6 +67,7 @@ export class YoutubeHeuristics implements SearchHeuristics<Partial<Video>> {
     }
 
     const channelNameScore = track.author.name.toLowerCase().includes(artist.toLowerCase()) ? 200 : 0;
+    const verifiedChannelScore = track.author.verified ? 200 : 0;
 
     return mean([
       titleScore,
@@ -75,7 +76,8 @@ export class YoutubeHeuristics implements SearchHeuristics<Partial<Video>> {
       promotedWordsScore,
       penalizedWordsScore,
       liveVideoScore,
-      channelNameScore
+      channelNameScore,
+      verifiedChannelScore
     ]);
   };
 


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->

- Added a new value called "verifiedChannelScore" inside the "heuristics.ts" file. 
- Added the newly created value to the "mean( )" function.

The verified channels now have  a significant weight while deciding what tracks to recommend on top of the list.