### PR TITLE
Fix: do not play section titles

### DIFF
--- a/packages/app/app/components/AlbumView/index.tsx
+++ b/packages/app/app/components/AlbumView/index.tsx
@@ -10,7 +10,7 @@ import TrackTableContainer from '../../containers/TrackTableContainer';
 import { AlbumDetailsState } from '../../reducers/search';
 
 type AlbumViewProps = {
-  album?: AlbumDetailsState 
+  album?: AlbumDetailsState
   isFavorite: boolean;
   searchAlbumArtist: React.MouseEventHandler;
   addAlbumToDownloads: React.MouseEventHandler;
@@ -88,7 +88,7 @@ export const AlbumView: React.FC<AlbumViewProps> = ({
                 }
                 <div className={styles.album_tracks}>
                   <label>{t('tracks')}</label>
-                  {album.tracklist.length}
+                  {album.tracklist.filter(track => track.type !== 'heading').length}
                 </div>
                 <div className={styles.album_buttons}>
                   <a
@@ -128,7 +128,7 @@ export const AlbumView: React.FC<AlbumViewProps> = ({
                 </div>
               </div>
             </div>
-            <TrackTableContainer 
+            <TrackTableContainer
               tracks={album.tracklist}
               displayDeleteButton={false}
               displayThumbnail={false}

--- a/packages/app/app/containers/AlbumViewContainer/hooks.ts
+++ b/packages/app/app/containers/AlbumViewContainer/hooks.ts
@@ -64,7 +64,7 @@ export const useAlbumViewProps = () => {
   }, [album, dispatch, plugins]);
 
   const addAlbumToQueue = useCallback(async () => {
-    await album?.tracklist.forEach(async track => {
+    await album?.tracklist.filter(track => track.type !== 'heading').forEach(async track => {
       dispatch(QueueActions.addToQueue({
         artist: album?.artist,
         name: track.title,

--- a/packages/app/app/containers/PlayerBarContainer/hooks.ts
+++ b/packages/app/app/containers/PlayerBarContainer/hooks.ts
@@ -105,7 +105,7 @@ export const useTrackInfoProps = () => {
   const currentSong = _.get(queue.queueItems, queue.currentSong);
 
   const track = currentSong?.name;
-  const artist = currentSong?.artist;
+  const artist = currentSong?.artist?.name || currentSong?.artist;
   const cover = currentSong?.thumbnail;
 
   const favorite = useSelector(s => getFavoriteTrack(s, artist, track));
@@ -154,7 +154,7 @@ export const useToggleOptionCallback = (
   [name, settings, toggleOption]
 );
 
-export const useTrackDurationProp = () => { 
+export const useTrackDurationProp = () => {
   const settings = useSelector(settingsSelector);
   const trackDurationSetting = _.get(settings, 'trackDuration', false);
   return {
@@ -237,9 +237,9 @@ export const useStreamLookup = () => {
         dispatch(queueActions.findStreamForTrack(queue.currentSong));
         return;
       }
-    
+
       const nextTrackWithNoStream = queue.queueItems.findIndex((item) => isEmpty(item.stream));
-    
+
       if (nextTrackWithNoStream !== -1) {
         dispatch(queueActions.findStreamForTrack(nextTrackWithNoStream));
       }

--- a/packages/ui/lib/components/PlayerBar/index.tsx
+++ b/packages/ui/lib/components/PlayerBar/index.tsx
@@ -89,7 +89,7 @@ const PlayerBar: React.FC<PlayerBarProps> = ({
         <TrackInfo
           cover={cover}
           track={track}
-          artist={artist}
+          artist={artist || artist?.name}
           onTrackClick={onTrackClick}
           onArtistClick={onArtistClick}
           addToFavorites={addToFavorites}

--- a/packages/ui/lib/components/PlayerBar/index.tsx
+++ b/packages/ui/lib/components/PlayerBar/index.tsx
@@ -89,7 +89,7 @@ const PlayerBar: React.FC<PlayerBarProps> = ({
         <TrackInfo
           cover={cover}
           track={track}
-          artist={artist || artist?.name}
+          artist={artist}
           onTrackClick={onTrackClick}
           onArtistClick={onArtistClick}
           addToFavorites={addToFavorites}

--- a/packages/ui/lib/components/TrackTable/Cells/DeleteCell.tsx
+++ b/packages/ui/lib/components/TrackTable/Cells/DeleteCell.tsx
@@ -12,7 +12,7 @@ const DeleteCell: React.FC<CellProps<Track> & TrackTableExtraProps<Track>> = ({
   row,
   onDelete
 }) => <td {...cell.getCellProps() as TdHTMLAttributes<HTMLTableCellElement>} className={cx(styles.narrow, styles.delete_cell)}>
-  <Button
+  {(row.original?.type !== 'heading') && <Button
     data-testid='delete-button'
     basic
     borderless
@@ -20,7 +20,7 @@ const DeleteCell: React.FC<CellProps<Track> & TrackTableExtraProps<Track>> = ({
     size='tiny' 
     icon='times'
     onClick={() => onDelete(row.original, row.index)}
-  />
+  />}
 </td>;
 
 export default DeleteCell;

--- a/packages/ui/lib/components/TrackTable/Cells/FavoriteCell.tsx
+++ b/packages/ui/lib/components/TrackTable/Cells/FavoriteCell.tsx
@@ -14,13 +14,13 @@ const FavoriteCell: React.FC<CellProps<Track> & TrackTableExtraProps<Track>> = (
   onAddToFavorites,
   onRemoveFromFavorites
 }) => <td {...cell.getCellProps() as TdHTMLAttributes<HTMLTableCellElement>} className={cx(styles.favorite_cell, styles.narrow)}>
-  <Button
+  {(row.original?.type !== 'heading')&&<Button
     basic
     borderless
     circular
     size='tiny' icon={value ? 'heart' : 'heart outline'}
     onClick={() =>  value ? onRemoveFromFavorites(row.original) : onAddToFavorites(row.original)}
-  />
+  />}
 </td>;
 
 export default FavoriteCell;

--- a/packages/ui/lib/components/TrackTable/Cells/PositionCell.tsx
+++ b/packages/ui/lib/components/TrackTable/Cells/PositionCell.tsx
@@ -13,7 +13,7 @@ const PositionCell: React.FC<CellProps<Track> & TrackTableExtraProps<Track>> = (
   value,
   onPlay
 }) => <td {...cell.getCellProps() as TdHTMLAttributes<HTMLTableCellElement>} className={cx(styles.position_cell, styles.narrow)}>
-  <Button 
+  {(row.original?.type !== 'heading') && <Button 
     circular 
     size='tiny'
     icon='play'
@@ -21,7 +21,7 @@ const PositionCell: React.FC<CellProps<Track> & TrackTableExtraProps<Track>> = (
     className={styles.add_button}
     onClick={() => onPlay(row.original)}
     data-testid='play-now'
-  />
+  />}
   <span className={styles.position_cell_value}>
     {value ?? row.index+1}
   </span>

--- a/packages/ui/lib/components/TrackTable/Cells/SelectionCell.tsx
+++ b/packages/ui/lib/components/TrackTable/Cells/SelectionCell.tsx
@@ -12,7 +12,7 @@ const SelectionCell: React.FC<CellProps<Track> & UseRowSelectRowProps<Track>> = 
   row
 }) => <td {...cell.getCellProps() as TdHTMLAttributes<HTMLTableCellElement>} className={cx(styles.select_cell, styles.narrow)}>
   {/* @ts-ignore */}
-  <Checkbox {...row.getToggleRowSelectedProps()}/>
+  {(row.original?.type !== 'heading') && <Checkbox {...row.getToggleRowSelectedProps()}/>}
 </td>;
 
 export default SelectionCell;

--- a/packages/ui/lib/components/TrackTable/Cells/TitleCell.tsx
+++ b/packages/ui/lib/components/TrackTable/Cells/TitleCell.tsx
@@ -25,7 +25,7 @@ const TitleCell: React.FC<CellProps<Track> & TrackTableExtraProps<Track>> = ({
     <span className={styles.title_cell_value}>
       {value}
     </span>
-    <span className={styles.title_cell_buttons}>
+    {(row.original?.type !== 'heading') && <span className={styles.title_cell_buttons}>
       <Button
         className={styles.title_cell_button}
         basic
@@ -71,7 +71,7 @@ const TitleCell: React.FC<CellProps<Track> & TrackTableExtraProps<Track>> = ({
 
         strings={popupActionStrings}
       />
-    </span>
+    </span>}
   </span>
 </td>;
 

--- a/packages/ui/lib/components/TrackTable/Headers/SelectionHeader.tsx
+++ b/packages/ui/lib/components/TrackTable/Headers/SelectionHeader.tsx
@@ -22,8 +22,9 @@ const SelectionHeader: React.FC<
   strings
 }) => {
   const checkboxProps = getToggleAllRowsSelectedProps();
-  const selectedTracks = selectedFlatRows.map(row => row.original);
-
+  const selectedTracks = selectedFlatRows
+    .map(row => row.original)
+    .filter(row => row?.type !== 'heading');
 
   return <span className={styles.select_header}>
     {

--- a/packages/ui/lib/types.ts
+++ b/packages/ui/lib/types.ts
@@ -11,6 +11,7 @@ export type Track = {
   image?: { '#text'?: string }[];
   stream?: TrackStream;
   uuid?: string;
+  type?: string;
 };
 
 export type Album = {

--- a/packages/ui/stories/components/trackTable.stories.tsx
+++ b/packages/ui/stories/components/trackTable.stories.tsx
@@ -15,12 +15,21 @@ export default {
 
 const tracks = [
   {
+    position: 0,
+    thumbnail: 'https://i.imgur.com/4euOws2.jpg',
+    artist: 'Test Artist',
+    title: 'Title',
+    album: 'Test Album',
+    duration: '1:00',
+    type: 'heading'
+  }, {
     position: 1,
     thumbnail: 'https://i.imgur.com/4euOws2.jpg',
     artist: 'Test Artist',
     title: 'Test Title',
     album: 'Test Album',
-    duration: '1:00'
+    duration: '1:00',
+    type: 'track'
   }, {
     position: 2,
     thumbnail: 'https://i.imgur.com/4euOws2.jpg',
@@ -79,7 +88,7 @@ export const Empty = () => <div className='bg'>
   />
 </div>;
 
-export const WithRows = () => <div className='bg'>
+export const WithRowsAndTitles = () => <div className='bg'>
   <TrackTable
     tracks={tracks}
     positionHeader={<Icon name='hashtag' />}

--- a/packages/ui/test/__snapshots__/trackTable.test.tsx.snap
+++ b/packages/ui/test/__snapshots__/trackTable.test.tsx.snap
@@ -599,3 +599,417 @@ exports[`(Snapshot) Track table - example data with all rows should render corre
   </table>
 </DocumentFragment>
 `;
+
+exports[`(Snapshot) Track table - example data with titles should render correctly 1`] = `
+<DocumentFragment>
+  <table
+    class="track_table"
+    role="table"
+  >
+    <thead>
+      <tr
+        role="row"
+      >
+        <th
+          colspan="1"
+          role="columnheader"
+        >
+           
+        </th>
+        <th
+          colspan="1"
+          role="columnheader"
+        >
+          <span
+            class="center_aligned"
+          >
+            Position
+          </span>
+        </th>
+        <th
+          colspan="1"
+          role="columnheader"
+        >
+          <span
+            class="center_aligned"
+          >
+            <i
+              aria-hidden="true"
+              class="image icon"
+            />
+          </span>
+        </th>
+        <th
+          colspan="1"
+          role="columnheader"
+        >
+           
+        </th>
+        <th
+          colspan="1"
+          role="columnheader"
+        >
+          Title
+        </th>
+        <th
+          colspan="1"
+          role="columnheader"
+        >
+          Artist
+        </th>
+        <th
+          colspan="1"
+          role="columnheader"
+        >
+          Album
+        </th>
+        <th
+          colspan="1"
+          role="columnheader"
+        >
+          <span
+            class="select_header"
+          >
+            <div
+              class="ui fitted checkbox nuclear checkbox"
+              style="cursor: pointer;"
+            >
+              <input
+                class="hidden"
+                readonly=""
+                tabindex="0"
+                title="Toggle All Rows Selected"
+                type="checkbox"
+                value=""
+              />
+              <label />
+            </div>
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      data-rbd-droppable-context-id="2"
+      data-rbd-droppable-id="track_table"
+      role="rowgroup"
+    >
+      <tr
+        class=""
+        data-rbd-draggable-context-id="2"
+        data-rbd-draggable-id="Test Title 0"
+        role="row"
+      >
+        <td
+          class="narrow delete_cell"
+          role="cell"
+        >
+          <button
+            class="ui tiny basic circular icon button nuclear button borderless"
+            data-testid="delete-button"
+          >
+            <i
+              aria-hidden="true"
+              class="times icon"
+            />
+          </button>
+        </td>
+        <td
+          class="position_cell narrow"
+          role="cell"
+        >
+          <button
+            class="ui pink tiny circular icon button nuclear button add_button"
+            data-testid="play-now"
+          >
+            <i
+              aria-hidden="true"
+              class="play icon"
+            />
+          </button>
+          <span
+            class="position_cell_value"
+          >
+            1
+          </span>
+        </td>
+        <td
+          class="thumbnail_cell narrow"
+          role="cell"
+        >
+          <img
+            class="thumbnail"
+            src="https://i.imgur.com/4euOws2.jpg"
+          />
+        </td>
+        <td
+          class="favorite_cell narrow"
+          role="cell"
+        >
+          <button
+            class="ui tiny basic circular icon button nuclear button borderless"
+          >
+            <i
+              aria-hidden="true"
+              class="heart outline icon"
+            />
+          </button>
+        </td>
+        <td
+          class="title_cell"
+          role="cell"
+        >
+          <span
+            class="title_cell_content"
+          >
+            <span
+              class="title_cell_value"
+            >
+              Test Title
+            </span>
+            <span
+              class="title_cell_buttons"
+            >
+              <button
+                class="ui tiny basic circular icon button nuclear button borderless title_cell_button"
+                data-testid="add-to-queue"
+              >
+                <i
+                  aria-hidden="true"
+                  class="plus icon"
+                />
+              </button>
+              <button
+                class="ui tiny basic circular icon button nuclear button borderless title_cell_button"
+                data-testid="track-popup-trigger"
+              >
+                <i
+                  aria-hidden="true"
+                  class="ellipsis horizontal icon"
+                />
+              </button>
+            </span>
+          </span>
+        </td>
+        <td
+          role="cell"
+        >
+          Test Artist
+        </td>
+        <td
+          role="cell"
+        >
+          Test Album
+        </td>
+        <td
+          class="select_cell narrow"
+          role="cell"
+        >
+          <div
+            class="ui fitted checkbox nuclear checkbox"
+            style="cursor: pointer;"
+          >
+            <input
+              class="hidden"
+              readonly=""
+              tabindex="0"
+              title="Toggle Row Selected"
+              type="checkbox"
+              value=""
+            />
+            <label />
+          </div>
+        </td>
+      </tr>
+      <tr
+        class=""
+        data-rbd-draggable-context-id="2"
+        data-rbd-draggable-id="Title 1"
+        role="row"
+      >
+        <td
+          class="narrow delete_cell"
+          role="cell"
+        />
+        <td
+          class="position_cell narrow"
+          role="cell"
+        >
+          <span
+            class="position_cell_value"
+          >
+            2
+          </span>
+        </td>
+        <td
+          class="thumbnail_cell narrow"
+          role="cell"
+        >
+          <img
+            class="thumbnail"
+            src="https://i.imgur.com/4euOws2.jpg"
+          />
+        </td>
+        <td
+          class="favorite_cell narrow"
+          role="cell"
+        />
+        <td
+          class="title_cell"
+          role="cell"
+        >
+          <span
+            class="title_cell_content"
+          >
+            <span
+              class="title_cell_value"
+            >
+              Title
+            </span>
+          </span>
+        </td>
+        <td
+          role="cell"
+        >
+          Test Artist 2
+        </td>
+        <td
+          role="cell"
+        >
+          Test Album
+        </td>
+        <td
+          class="select_cell narrow"
+          role="cell"
+        />
+      </tr>
+      <tr
+        class=""
+        data-rbd-draggable-context-id="2"
+        data-rbd-draggable-id="Test Title 3 2"
+        role="row"
+      >
+        <td
+          class="narrow delete_cell"
+          role="cell"
+        >
+          <button
+            class="ui tiny basic circular icon button nuclear button borderless"
+            data-testid="delete-button"
+          >
+            <i
+              aria-hidden="true"
+              class="times icon"
+            />
+          </button>
+        </td>
+        <td
+          class="position_cell narrow"
+          role="cell"
+        >
+          <button
+            class="ui pink tiny circular icon button nuclear button add_button"
+            data-testid="play-now"
+          >
+            <i
+              aria-hidden="true"
+              class="play icon"
+            />
+          </button>
+          <span
+            class="position_cell_value"
+          >
+            3
+          </span>
+        </td>
+        <td
+          class="thumbnail_cell narrow"
+          role="cell"
+        >
+          <img
+            class="thumbnail"
+            src="https://i.imgur.com/4euOws2.jpg"
+          />
+        </td>
+        <td
+          class="favorite_cell narrow"
+          role="cell"
+        >
+          <button
+            class="ui tiny basic circular icon button nuclear button borderless"
+          >
+            <i
+              aria-hidden="true"
+              class="heart outline icon"
+            />
+          </button>
+        </td>
+        <td
+          class="title_cell"
+          role="cell"
+        >
+          <span
+            class="title_cell_content"
+          >
+            <span
+              class="title_cell_value"
+            >
+              Test Title 3
+            </span>
+            <span
+              class="title_cell_buttons"
+            >
+              <button
+                class="ui tiny basic circular icon button nuclear button borderless title_cell_button"
+                data-testid="add-to-queue"
+              >
+                <i
+                  aria-hidden="true"
+                  class="plus icon"
+                />
+              </button>
+              <button
+                class="ui tiny basic circular icon button nuclear button borderless title_cell_button"
+                data-testid="track-popup-trigger"
+              >
+                <i
+                  aria-hidden="true"
+                  class="ellipsis horizontal icon"
+                />
+              </button>
+            </span>
+          </span>
+        </td>
+        <td
+          role="cell"
+        >
+          Test Artist 3
+        </td>
+        <td
+          role="cell"
+        >
+          Test Album
+        </td>
+        <td
+          class="select_cell narrow"
+          role="cell"
+        >
+          <div
+            class="ui fitted checkbox nuclear checkbox"
+            style="cursor: pointer;"
+          >
+            <input
+              class="hidden"
+              readonly=""
+              tabindex="0"
+              title="Toggle Row Selected"
+              type="checkbox"
+              value=""
+            />
+            <label />
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</DocumentFragment>
+`;

--- a/packages/ui/test/trackTable.test.tsx
+++ b/packages/ui/test/trackTable.test.tsx
@@ -58,3 +58,43 @@ makeSnapshotTest(
   },
   '(Snapshot) Track table - example data with all rows'
 );
+
+makeSnapshotTest(
+  TrackTable,
+  {
+    tracks: [
+      {
+        position: 1,
+        thumbnail: 'https://i.imgur.com/4euOws2.jpg',
+        artist: 'Test Artist',
+        title: 'Test Title',
+        album: 'Test Album',
+        duration: '1:00'
+      }, {
+        position: 2,
+        thumbnail: 'https://i.imgur.com/4euOws2.jpg',
+        artist: 'Test Artist 2',
+        name: 'Title',
+        album: 'Test Album',
+        type: 'heading'
+      } as Track,
+      {
+        position: 3,
+        thumbnail: 'https://i.imgur.com/4euOws2.jpg',
+        artist: {name: 'Test Artist 3' },
+        name: 'Test Title 3',
+        album: 'Test Album',
+        duration: '1:00'
+      } as Track
+    ],
+    positionHeader: 'Position',
+    thumbnailHeader: <Icon name='image' />,
+    artistHeader: 'Artist',
+    albumHeader: 'Album',
+    titleHeader: 'Title',
+    durationHeader: 'Length',
+    isTrackFavorite:
+      (track: Track) => track.artist === 'Test Artist 2'
+  },
+  '(Snapshot) Track table - example data with titles'
+);


### PR DESCRIPTION
Closes #1168 

**Changes**
- Disable playing/adding to playlist/etc of the tracks of type "heading"
- Fix a bug that some albums cannot be played with "Play now" button. I fixed this bug in the current PR, because it was very obvious during the testing of the implemented feature. But maybe another ticket could be created to make sure that artist prop has the same structure regardless from where the track comes?

**Tests**
- I updated existing TrackTable story & added snapshot test for tracklist that has headings.

**Open questions**
- I am not sure if I used the best approach. So if you have a tip for me on how proposed solution can be improved, I'd be stoked.
- Are there some other tests that you would recommend to add?

**Screenshots**
![image](https://user-images.githubusercontent.com/115021350/202705998-3412dce7-4ccf-42f7-bdde-b65f7e5582bb.png)
