### PR TITLE
fix: Listening history container locale date time test fix

### DIFF
--- a/packages/app/app/containers/ListeningHistoryContainer/ListeningHistoryContainer.test.tsx
+++ b/packages/app/app/containers/ListeningHistoryContainer/ListeningHistoryContainer.test.tsx
@@ -19,12 +19,12 @@ jest.mock('electron', () => ({
         uuid: 'test',
         artist: 'test artist',
         title: 'test title',
-        createdAt: new Date('2020-01-01')
+        createdAt: new Date('2020-01-01, 12:00')
       }, {
         uuid: 'test2',
         artist: 'test artist2',
         title: 'test title 2',
-        createdAt: new Date('2020-01-02')
+        createdAt: new Date('2020-01-02, 12:00')
       }],
       cursor: {
         beforeCursor: null,
@@ -40,15 +40,18 @@ describe('Listening history container', () => {
   it('renders the listening history', async () => {
     const { component } = mountComponent();
 
+    const makeLocalDate = (dateString) => new Date(dateString).toLocaleDateString();
+    const makeLocalTime = (dateString) => new Date(dateString).toLocaleTimeString();
+
     await Promise.all([
-      '1/1/2020',
+      makeLocalDate('2020-01-01'),
       'test title',
       'test artist',
-      '1/1/2020, 12:00:00 AM',
-      '1/2/2020',
+      `${makeLocalDate('2020,01,01')}, ${makeLocalTime('2020,01,01, 12:00')}`,
+      makeLocalDate('2020-01-02'),
       'test title 2',
       'test artist2',
-      '1/2/2020, 12:00:00 AM'
+      `${makeLocalDate('2020,01,02')}, ${makeLocalTime('2020,01,02, 12:00')}`
     ].map(async text => {
       expect(await component.findByText(text)).toBeInTheDocument();
     }));

--- a/packages/app/app/containers/ListeningHistoryContainer/ListeningHistoryContainer.test.tsx
+++ b/packages/app/app/containers/ListeningHistoryContainer/ListeningHistoryContainer.test.tsx
@@ -40,18 +40,26 @@ describe('Listening history container', () => {
   it('renders the listening history', async () => {
     const { component } = mountComponent();
 
-    const makeLocalDate = (dateString) => new Date(dateString).toLocaleDateString();
-    const makeLocalTime = (dateString) => new Date(dateString).toLocaleTimeString();
+    const makeLocal = (dateString, timeString?) => {
+      const date = new Date(dateString).toLocaleDateString();
+
+      if (timeString) {
+        const time = new Date(`${dateString}, ${timeString}`).toLocaleTimeString();
+        return `${date}, ${time}`;
+      } else {
+        return date;
+      }
+    };
 
     await Promise.all([
-      makeLocalDate('2020-01-01'),
+      makeLocal('2020-01-01'),
       'test title',
       'test artist',
-      `${makeLocalDate('2020,01,01')}, ${makeLocalTime('2020,01,01, 12:00')}`,
-      makeLocalDate('2020-01-02'),
+      makeLocal('2020,01,01', '12:00'),
+      makeLocal('2020-01-02'),
       'test title 2',
       'test artist2',
-      `${makeLocalDate('2020,01,02')}, ${makeLocalTime('2020,01,02, 12:00')}`
+      makeLocal('2020,01,02', '12:00')
     ].map(async text => {
       expect(await component.findByText(text)).toBeInTheDocument();
     }));


### PR DESCRIPTION
Fixes issue when tests are run in a locale which differs from expected. 

EG: When running tests on my machine in the UK, the date is formatted as  "01/01/2020". The test is expecting a date string of "1/1/2020". 

Any thoughts? 🤔 
