### PR TITLE
fix: hide cookie banner on spotify import page

### DIFF
--- a/packages/core/src/helpers/playlist/spotify.ts
+++ b/packages/core/src/helpers/playlist/spotify.ts
@@ -47,12 +47,10 @@ export default (async function () {
   }
 
   function getTracksFromDOM(processedIndex) {
-    const cookieOptions = document.getElementById('#onetrust-pc-btn-handler');
+    const cookieBanner = document.getElementById('#onetrust-banner-sdk');
 
-    if (cookieOptions) {
-      cookieOptions.click();
-      const acceptMinimalCookies = document.querySelector('.save-preference-btn-handler.onetrust-close-btn-handler.button-theme') as HTMLElement;
-      acceptMinimalCookies.click();
+    if (cookieBanner) {
+      cookieBanner.style.setProperty('display', 'none', 'important');
     }
     
     const nodeTracks = document.querySelector('div[data-testid="top-sentinel"] + div').childNodes as NodeListOf<Element>;

--- a/packages/core/src/helpers/playlist/spotify.ts
+++ b/packages/core/src/helpers/playlist/spotify.ts
@@ -47,6 +47,14 @@ export default (async function () {
   }
 
   function getTracksFromDOM(processedIndex) {
+    const cookieOptions = document.getElementById('#onetrust-pc-btn-handler');
+
+    if (cookieOptions) {
+      cookieOptions.click();
+      const acceptMinimalCookies = document.querySelector('.save-preference-btn-handler.onetrust-close-btn-handler.button-theme') as HTMLElement;
+      acceptMinimalCookies.click();
+    }
+    
     const nodeTracks = document.querySelector('div[data-testid="top-sentinel"] + div').childNodes as NodeListOf<Element>;
     const tracks = [];
 


### PR DESCRIPTION
Hides the cookie banner on the spotify import playlist page.
