### PR TITLE
fix: add tmate to coverage.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Use Node.js 16
         uses: actions/setup-node@master
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,8 +15,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Use Node.js 16
         uses: actions/setup-node@master
         with:
@@ -24,6 +22,8 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Run coverage
         run: npm run coverage
       - name: Upload coverage to Codecov

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ![nuclear](https://i.imgur.com/oT1006i.png) 
 [![nuclear](https://snapcraft.io//nuclear/badge.svg)](https://snapcraft.io/nuclear) [![Discord](https://img.shields.io/badge/Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/JqPjKxE)
 
-Desktop music player focused on streaming from free sources
+Desktop music player focused on streaming from free sources.
 
 ![Showcase](https://i.imgur.com/8qHu66J.png)
 

--- a/packages/app/app/containers/PlaylistViewContainer/__snapshots__/PlaylistViewContainer.test.tsx.snap
+++ b/packages/app/app/containers/PlaylistViewContainer/__snapshots__/PlaylistViewContainer.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`Playlist view container should display a playlist 1`] = `
                 ·
               </span>
               <span>
-                Last modified: 9/11/2001, 8:46:40 AM
+                Last modified: 9/11/2001, 8:46:40 AM
               </span>
             </div>
             <div


### PR DESCRIPTION
Allows SSH connection to the coverage action task runner for debugging. If it works we can setup SSH keys, currently anyone watching the coverage task action can get the connection string.

Documentation is here : https://mxschmitt.github.io/action-tmate/