### PR TITLE
feat: display track loading state on seekbar

### DIFF
--- a/packages/ui/lib/components/Seekbar/index.tsx
+++ b/packages/ui/lib/components/Seekbar/index.tsx
@@ -70,7 +70,8 @@ const Seekbar: React.FC<SeekbarProps> = ({
       data-testid='seekbar'
       className={cx(
         common.nuclear,
-        styles.seekbar
+        styles.seekbar,
+        isLoading ? 'loading' : ''
       )}
       onClick={handleClick(seek)}
       style={{ height }}

--- a/packages/ui/lib/components/Seekbar/styles.scss
+++ b/packages/ui/lib/components/Seekbar/styles.scss
@@ -8,6 +8,25 @@
   flex: 0 0 auto;
   transition: height 0.25s;
 
+  &.loading::after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    transform: translateX(-100%);
+    background-image: linear-gradient(
+      90deg,
+      rgba(lightgray, 0) 0,
+      rgba(lightgray, 0.2) 25%,
+      rgba(lightgray, 0.5) 50%,
+      rgba(lightgray, 0.7) 75%,
+      rgba(lightgray, 0)
+    );
+    animation: shimmer 2s infinite;
+    content: '';
+  }
+
   .seekbar_progress {
     height: 100%;
     background-color: $pink;
@@ -17,6 +36,12 @@
     position: absolute;
     background-color: rgba($blue, 0.75);
     height: 100%;
+  }
+
+  @keyframes shimmer {
+    100% {
+      transform: translateX(100%);
+    }
   }
 
 }

--- a/packages/ui/stories/components/seekbar.stories.tsx
+++ b/packages/ui/stories/components/seekbar.stories.tsx
@@ -28,6 +28,14 @@ export const Basic = () => (
   </div>
 );
 
+export const Loading = () => (
+  <div>
+    Seekbar while loading a track.
+    <br/><br/>
+    <Seekbar isLoading />
+  </div>
+);
+
 export const WithSkippableSegments = () => <div style={{
   display: 'flex',
   flexFlow: 'column',


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->

Fixes #1373 

## Implementation:
Added a loading shimmer effect on Seekbar if the track is in a loading State.

## Screenshots:
![electron_vzaw43nwPY](https://user-images.githubusercontent.com/20613798/230828169-799e6799-727a-4fb6-b517-8dd8ee5d06a2.gif)


