### PR TITLE
Fix typos and update the PT-BR version of electron.md

### DIFF
--- a/docs/electron-ptbr.md
+++ b/docs/electron-ptbr.md
@@ -1,14 +1,15 @@
-## E se eu for completamente contra Electron?
+## E se eu for religiosamente contra utilizar o Electron?
 
-Então você não é o público alvo deste programa. Cheque o mps-youtube (link acima) para um programa similar que nao irá manchar sua máquina com uma biblioteca que você não gosta.
+Então você não é o público alvo deste programa. Confira este link [mps-youtube](https://github.com/mps-youtube/mps-youtube) para ver um programa similar que não irá sujar sua máquina com uma lib que você não gosta.
 
-MUdando de assunto, opiniões muito polarizadas sobre linguagens e frameworks são características de pessoas que não possuem experiências programando no mundo real e estão mais interessadas em criar uma identidade do que programa de computador.
+É nítido que opiniões muito polarizadas sobre linguagens e frameworks são características de pessoas que não possuem experiência de programação no mundo real e estão mais interessadas em criar uma identidade do que programas de computador. Quando pressionadas a darem razões que justifiquem o porquê do Electron ser tão ruim, raramente elas oferecem argumentos úteis e recorrem aos clássicos "consumo de memória" ou "m-mas isto é um browser inteiro" (e por sinal ambos os argumentos são falsos há anos, por exemplo o consumo de memória exigido pelo Electron teve melhorias significativas, mas o meme ficou). O mundo da programaçāo é cheio de pessoas que dão argumentos raivosos sobre o porquê da lib X ou Y ser um lixo e o porquê você deve odiá-la, e continuam repetindo o que quer seja que elas lembrem porque isso faz elas parecerem mais inteligentes do que realmente são, ao invés de fazerem uma análise crítica se o que elas falam realmente faz sentido.
 
-## Razões por trás de Electron
+## As Razões por detrás do Electron
 
-* Divertido de se desenvolver,
-* Usa o mesmo recurso que uma página web, se usado sanamente,
-* Provê uma pequena barreira para entrada de novos contribuidores,
-* Nos permite facilmente executar a build e fazer o deploy para a maioria das plataformas desktop (diversos sistemas Linux, macOS e Windows),
-* Nos permite usar React para manejar a GUI,
-* Nenhuma outra boa alternativa nos concederia estes benefícios (não quero ouvir falar sobre qt).
+- É divertido de desenvolver aplicativos
+- Usa tantos recursos quanto uma tab do browser, se usado de maneira sã
+- Oferece uma pequena barreira para entrada de novos contribuidores,
+- Nos permite facilmente buildar e fazer o deploy para a maioria das plataformas desktop (diversas distros do Linux, MacOS e Windows)
+- Nos permite usar o React para desenvoler a interface gráfica (GUI)
+- Nenhuma outra boa alternativa nos daria estes benefícios (não quero ouvir falar sobre qt, tenta utilizar o design deles).
+- Os usuários não dão a mínima pras tecnologias que você usa para desenvolver seu aplicativo.

--- a/docs/electron-ptbr.md
+++ b/docs/electron-ptbr.md
@@ -2,14 +2,16 @@
 
 Então você não é o público alvo deste programa. Confira este link [mps-youtube](https://github.com/mps-youtube/mps-youtube) para ver um programa similar que não irá sujar sua máquina com uma lib que você não gosta.
 
-É nítido que opiniões muito polarizadas sobre linguagens e frameworks são características de pessoas que não possuem experiência de programação no mundo real e estão mais interessadas em criar uma identidade do que programas de computador. Quando pressionadas a darem razões que justifiquem o porquê do Electron ser tão ruim, raramente elas oferecem argumentos úteis e recorrem aos clássicos "consumo de memória" ou "m-mas isto é um browser inteiro" (e por sinal ambos os argumentos são falsos há anos, por exemplo o consumo de memória exigido pelo Electron teve melhorias significativas, mas o meme ficou). O mundo da programaçāo é cheio de pessoas que dão argumentos raivosos sobre o porquê da lib X ou Y ser um lixo e o porquê você deve odiá-la, e continuam repetindo o que quer seja que elas lembrem porque isso faz elas parecerem mais inteligentes do que realmente são, ao invés de fazerem uma análise crítica se o que elas falam realmente faz sentido.
+É nítido que opiniões muito polarizadas sobre linguagens e frameworks são características de pessoas que não possuem experiência de programação no mundo real e estão mais interessadas em criar uma identidade do que programas de computador. Quando pressionadas a darem razões que justifiquem o porquê do Electron ser tão ruim, raramente elas oferecem argumentos úteis e recorrem aos clássicos "consumo de memória" ou "m-mas isto é um browser inteiro" (e por sinal ambos os argumentos são falsos há anos, por exemplo o consumo de memória exigido pelo Electron teve melhorias significativas, mas o meme ficou). O mundo da programaçāo é cheio de pessoas que dão argumentos raivosos sobre o porquê da lib X ou Y ser um lixo e o porquê você deve odiá-la, e continuam repetindo o que quer que seja que elas lembrem porque isso faz elas parecerem mais inteligentes, ao invés de fazerem uma análise crítica de se o que elas falam realmente faz sentido.
 
 ## As Razões por detrás do Electron
 
-- É divertido de desenvolver aplicativos
-- Usa tantos recursos quanto uma tab do browser, se usado de maneira sã
-- Oferece uma pequena barreira para entrada de novos contribuidores,
-- Nos permite facilmente buildar e fazer o deploy para a maioria das plataformas desktop (diversas distros do Linux, MacOS e Windows)
-- Nos permite usar o React para desenvoler a interface gráfica (GUI)
-- Nenhuma outra boa alternativa nos daria estes benefícios (não quero ouvir falar sobre qt, tenta utilizar o design deles).
-- Os usuários não dão a mínima pras tecnologias que você usa para desenvolver seu aplicativo.
+* É divertido de desenvolver nele
+* Usa tantos recursos quanto uma tab do browser, se usado de maneira sã
+* A barreira para entrada de novos contribuidores é pequena
+* Nos permite facilmente buildar e fazer o deploy para a maioria das plataformas desktop (diversas distros do Linux, MacOS e Windows)
+* Nos permite usar o React para desenvoler a interface gráfica (GUI)
+* Nenhuma outra boa alternativa nos daria estes benefícios (não quero ouvir falar sobre qt, tenta utilizar o design deles)
+* Os usuários não dão a mínima para as tecnologias que você usa no desenvolvimento do seu aplicativo
+
+Com a experiência vem uma certa apreciação dos tradeoffs que você faz ao desenvolver software e, embora o Electron não seja perfeito para cada situação, certamente se mostrou bom o suficiente para aquilo que tentei alcançar com o Nuclear.


### PR DESCRIPTION
This PR makes some corrections  on typos in the Brazilian version of the Electron.md and also syncs it with the English version.
