### PR TITLE
go back button restart song function added

### DIFF
--- a/packages/app/app/containers/PlayerBarContainer/PlayerBarContainer.test.tsx
+++ b/packages/app/app/containers/PlayerBarContainer/PlayerBarContainer.test.tsx
@@ -215,6 +215,30 @@ describe('PlayerBar container', () => {
     expect(state.queue.currentSong).toBe(0); 
   });
 
+  it('should go back to the beginning of current track if current track is the first song in the queue', async () => {
+    const { component, store } = mountComponent({
+      queue: {
+        currentSong: 0,
+        queueItems: [{
+          artist: 'test artist 1',
+          name: 'test track 1',
+          streams: [{
+            duration: 300,
+            title: 'test track 1',
+            skipSegments: []
+          }]
+        }]
+      },
+      player: {
+        seek: 12
+      }
+    });
+    const previousButton = await component.findByTestId('player-controls-back');
+    fireEvent.click(previousButton);
+    const state = store.getState();
+    expect(state.player.seek).toBe(0);
+    expect(state.queue.currentSong).toBe(0); 
+  });
 
   const mountComponent = (initialStore?: AnyProps) => {
     const store = configureMockStore({

--- a/packages/app/app/containers/PlayerBarContainer/hooks.ts
+++ b/packages/app/app/containers/PlayerBarContainer/hooks.ts
@@ -64,7 +64,7 @@ export const usePlayerControlsProps = () => {
 
   const couldPlay = queue.queueItems.length > 0;
   const couldForward = couldPlay && queue.currentSong + 1 < queue.queueItems.length;
-  const couldBack = couldPlay && queue.currentSong > 0;
+  const couldBack = couldPlay;
   const goBackThreshold = ((
     settings.skipSponsorblock && 
       currentTrackStream?.skipSegments?.find(segment => segment.startTime === 0)?.endTime) 
@@ -84,6 +84,8 @@ export const usePlayerControlsProps = () => {
     () => {
       if (seek > goBackThreshold){
         dispatch(playerActions.updateSeek(0));
+      } else if (queue.currentSong === 0) {
+        dispatch(playerActions.resetPlayer());
       } else {
         dispatch(queueActions.previousSong());
       }


### PR DESCRIPTION
I have changed what actions will be dispatched to the go-back button under PlayerBarContainer. When you hit go back when playing the first song in the queue, the song should restart from the beginning. If there are other songs before the current song in the queue, go back button will still go to the previous song. 