### PR TITLE
Allow Spotify playlists that have tracks with empty thumbnails to be processed correctly

### DIFF
--- a/packages/core/src/helpers/playlist/spotify.ts
+++ b/packages/core/src/helpers/playlist/spotify.ts
@@ -75,7 +75,7 @@ export default (async function () {
           track.thumbnail = nodeDetails
             .querySelector('div[aria-colindex="2"]')
             .querySelector('img')
-            .getAttribute('src');
+            ?.getAttribute('src');
 
           const titleAndArtist = nodeDetails
             .querySelector<HTMLElement>('div[aria-colindex="2"]')


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->

Hi,

Submitting this as my playlist contains a track with no thumbnail and requires this fix for the playlist to be processed.
