### PR TITLE
Small changes to fix visual issues with mini player

### DIFF
--- a/packages/ui/lib/components/MiniPlayer/MiniPlayOptions/index.tsx
+++ b/packages/ui/lib/components/MiniPlayer/MiniPlayOptions/index.tsx
@@ -60,7 +60,9 @@ const MiniPlayOptions: React.FC<MiniPlayOptionsProps> = ({
         />
       </button>
       {
-        isExpanded && playOptions.map(playOption => <MiniPlayOptionControl {...playOption} />)
+        isExpanded && playOptions.filter(playOption => {
+          return playOption.dataTestId !== 'mini-player-play-option';
+        }).map(playOption => <MiniPlayOptionControl {...playOption} />)
       }
     </NeumorphicBox>
   </div>;

--- a/packages/ui/lib/components/MiniPlayer/MiniPlayOptions/styles.scss
+++ b/packages/ui/lib/components/MiniPlayer/MiniPlayOptions/styles.scss
@@ -32,4 +32,8 @@
      margin: 0;
    }
  }
+
+ &.neumorphic_box {
+  z-index: 1;
+ }
 }


### PR DESCRIPTION
Updated a few lines of code to correct issue #1396 by adding z-index under the related Sass file. Also found it a bit visually confusing to have playOptions show the mini player toggle when there is an existing NeumorphicBox _exclusively_ to exit - so filtered it out.

I didn't see any related existing tests, and changes are relatively finite in scope but happy to circle on that, if needed.