### PR TITLE
Discord Activity Fixes

### DIFF
--- a/packages/main/src/services/discord/index.ts
+++ b/packages/main/src/services/discord/index.ts
@@ -46,7 +46,7 @@ class Discord {
 
   async play() {
     if (this.isReady && this.activity) {
-      this.pausedTotal += Date.now() - (this.pauseStart || Date.now());
+      this.pausedTotal += Date.now() - this.pauseStart;
       if (this.activity) {
         if (this.isPaused) {
           // Remove "(Paused)" after song title

--- a/packages/main/src/services/discord/index.ts
+++ b/packages/main/src/services/discord/index.ts
@@ -78,6 +78,7 @@ class Discord {
   }
 
   async trackChange(track: NuclearMeta) {
+    this.isPaused = false;
     this.baseStart = Date.now();
     this.pausedTotal = 0;
     this.activity = {

--- a/packages/main/src/services/discord/index.ts
+++ b/packages/main/src/services/discord/index.ts
@@ -9,6 +9,7 @@ import Logger, { $mainLogger } from '../logger';
 class Discord {
   private rpc: DiscordRPC.Client;
   private isReady = false;
+  private isPaused = false;
   private baseStart: number;
   private pauseStart: number;
   private pausedTotal = 0;
@@ -36,7 +37,8 @@ class Discord {
     if (this.isReady && this.activity) {
       this.pauseStart = Date.now();
   
-      this.activity.details += '\nPaused';
+      this.activity.details = `${this.activity.details} (Paused)`;
+      this.isPaused = true;
       this.activity.startTimestamp = this.pauseStart;
       return this.sendActivity();
     }
@@ -44,9 +46,13 @@ class Discord {
 
   async play() {
     if (this.isReady && this.activity) {
-      this.pausedTotal += Date.now() - this.pauseStart;
+      this.pausedTotal += Date.now() - (this.pauseStart || Date.now());
       if (this.activity) {
-        this.activity.details = this.activity.details.substr(0, this.activity.details.length - 8);
+        if (this.isPaused) {
+          // Remove "(Paused)" after song title
+          this.activity.details = this.activity.details.substring(0, this.activity.details.length - 9);
+          this.isPaused = false;
+        }
         this.activity.startTimestamp = this.baseStart + this.pausedTotal;
         return this.sendActivity();
       }


### PR DESCRIPTION
- Fixes Discord activity, removing the last 8 characters of the song title.
- Fixes Discord activity elapsed timer not starting on first song.