### PR TITLE
Fixed #1422

### DIFF
--- a/packages/app/app/containers/MiniPlayerContainer/index.tsx
+++ b/packages/app/app/containers/MiniPlayerContainer/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { MiniPlayer } from '@nuclear/ui';
 
 import {
@@ -8,6 +8,8 @@ import {
   useVolumeControlsProps
 } from '../PlayerBarContainer/hooks';
 import { useMiniPlayerSettings } from './hooks';
+import { ipcRenderer } from 'electron';
+import { IpcEvents } from '@nuclear/core';
 
 
 const MiniPlayerContainer: React.FC = () => {
@@ -20,6 +22,14 @@ const MiniPlayerContainer: React.FC = () => {
     isMiniPlayerEnabled,
     toggleMiniPlayer
   } = useMiniPlayerSettings();
+
+  useEffect(() => {
+    if (isMiniPlayerEnabled) {
+      ipcRenderer.send(IpcEvents.WINDOW_MINIFY);
+    } else {
+      ipcRenderer.send(IpcEvents.WINDOW_RESTORE);
+    }
+  }, [isMiniPlayerEnabled]);
 
   return isMiniPlayerEnabled
     ? (

--- a/packages/core/src/ipc/events.ts
+++ b/packages/core/src/ipc/events.ts
@@ -47,6 +47,8 @@ enum IpcEvents {
 
   WINDOW_MINIMIZE = 'minimize',
   WINDOW_MAXIMIZE = 'maximize',
+  WINDOW_MINIFY = 'minify',
+  WINDOW_RESTORE = 'restore',
   WINDOW_CLOSE = 'close',
   WINDOW_OPEN_DEVTOOLS = 'open-devtools',
 

--- a/packages/main/__mocks__/@nuclear/core.ts
+++ b/packages/main/__mocks__/@nuclear/core.ts
@@ -2,7 +2,7 @@ export default jest.fn();
 export const settingsConfig = jest.requireActual('@nuclear/core/src/settings').settingsConfig;
 
 export enum IpcEvents {
-    STARTED = 'started',
+  STARTED = 'started',
 
   PLAY = 'play',
   PAUSE = 'pause',
@@ -50,6 +50,8 @@ export enum IpcEvents {
 
   WINDOW_MINIMIZE = 'minimize',
   WINDOW_MAXIMIZE = 'maximize',
+  WINDOW_MINIFY = 'minify',
+  WINDOW_RESTORE = 'restore',
   WINDOW_CLOSE = 'close',
   WINDOW_OPEN_DEVTOOLS = 'open-devtools',
 

--- a/packages/main/src/controllers/settings.ts
+++ b/packages/main/src/controllers/settings.ts
@@ -41,6 +41,16 @@ class SettingsIpcCtrl {
     this.window.maximize();
   }
 
+  @ipcEvent(IpcEvents.WINDOW_MINIFY)
+  onMinify() {
+    this.window.minify();
+  }
+
+  @ipcEvent(IpcEvents.WINDOW_RESTORE)
+  onRestore() {
+    this.window.restoreDefaultSize();
+  }
+
   @ipcEvent(IpcEvents.WINDOW_OPEN_DEVTOOLS)
   openDevtools() {
     this.window.openDevTools();

--- a/packages/main/src/services/config/index.ts
+++ b/packages/main/src/services/config/index.ts
@@ -29,6 +29,8 @@ class Config {
   thumbCleanInterval: number;
   localLibraryDbName: string;
   listeningHistoryDbName: string;
+  defaultWidth: number;
+  defaultHeight: number;
 
   constructor(
     @inject($mainLogger) logger: Logger
@@ -48,6 +50,9 @@ class Config {
     this.thumbCleanInterval = 30;
     this.localLibraryDbName = 'nuclear-local-db.sqlite';
     this.listeningHistoryDbName = 'nuclear-listening-history.sqlite';
+
+    this.defaultWidth = 1366;
+    this.defaultHeight = 768;
 
     dotenv.config({
       path: path.resolve(__dirname, '.env')

--- a/packages/main/src/services/window/index.ts
+++ b/packages/main/src/services/window/index.ts
@@ -33,6 +33,8 @@ class Window {
   private browserWindow: BrowserWindow;
   private isReady: Promise<void>;
   private resolve: () => void;
+  private defaultWidth: number;
+  private defaultHeight: number;
 
   constructor(
     @inject(Config) private config: Config,
@@ -43,10 +45,13 @@ class Window {
   ) {
     const icon = nativeImage.createFromPath(config.icon);
 
+    this.defaultWidth = config.defaultWidth;
+    this.defaultHeight = config.defaultHeight;
+
     this.browserWindow = new BrowserWindow({
       title: config.title,
-      width: 1366,
-      height: 768,
+      width: this.defaultWidth,
+      height: this.defaultHeight,
       minWidth: 330,
       minHeight: 450,
       
@@ -119,6 +124,21 @@ class Window {
     } else {
       this.browserWindow.isMaximized() ? this.browserWindow.unmaximize() : this.browserWindow.maximize();
     }
+  }
+
+  minify() {
+    // Unmaximize the window if it's maximized
+    if (this.platform.isMac()) {
+      this.browserWindow.isFullScreen() && this.browserWindow.setFullScreen(false);
+    } else {
+      this.browserWindow.isMaximized() && this.browserWindow.unmaximize();
+    }
+
+    this.browserWindow.setSize(0, 0, true);
+  }
+
+  restoreDefaultSize() {
+    this.browserWindow.setSize(this.defaultWidth, this.defaultHeight, true);
   }
 
   restore() {


### PR DESCRIPTION
Not 100% how to test this: please comment and I'll fix it ASAP. Issue: #1422 

Essentially I save a default size which the display defaults to on expand from miniplayer, and automatically set minimum size when we go to miniplayer. I also unmaximize the window if it is maximized before going to miniplayer.

This is done via an ipc message send in a useeffect whenever the miniplayer detects that miniplayer enablement is changed.