### PR TITLE
FEAT: Add "copy to clipboard" feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50122,7 +50122,7 @@
         "react-full-screen": "^1.0.1",
         "react-hifi": "^2.2.1",
         "react-hls-player": "^3.0.1",
-        "react-hot-loader": "^4.12",
+        "react-hot-loader": "^4.13.1",
         "react-i18next": "^11.12.0",
         "react-image": "^2.2.2",
         "react-list": "^0.8.13",

--- a/packages/ui/lib/components/TrackInfo/index.tsx
+++ b/packages/ui/lib/components/TrackInfo/index.tsx
@@ -4,6 +4,15 @@ import { Icon } from 'semantic-ui-react';
 import Cover from '../Cover';
 import styles from './styles.scss';
 
+const CopyTextToClipboard = async () => {
+  const track_element = document.getElementById('track_name');
+  try {
+    await navigator.clipboard.writeText(track_element.innerHTML);
+  } catch (err) {
+    console.error('Failed to copy: ', err);
+  }
+};
+
 export type TrackInfoProps = {
   cover?: string;
   track: string;
@@ -33,7 +42,7 @@ const TrackInfo: React.FC<TrackInfoProps> = ({
       hasTracks &&
         <>
           <div className={styles.artist_part}>
-            <div className={styles.track_name} onClick={onTrackClick}>
+            <div id='track_name' className={styles.track_name} onClick={() => CopyTextToClipboard()}>
               {track}
             </div>
             <div className={styles.artist_name} onClick={onArtistClick}>

--- a/packages/ui/lib/components/TrackInfo/styles.scss
+++ b/packages/ui/lib/components/TrackInfo/styles.scss
@@ -47,4 +47,8 @@
       cursor: pointer;
     }
   }
+
+  #track_name:hover {
+    color: green;
+  }
 }


### PR DESCRIPTION
In this pull request, users can now able to copy the song title to the clipboard by simply clicking on its name. 

Fixes #1516 

Demonstration Video
https://github.com/nukeop/nuclear/assets/75296055/87a86b75-63bc-47b8-90b4-9343f09a010a

