### PR TITLE
Fix Bandcamp plugin search aborting after the first page

### DIFF
--- a/packages/core/src/plugins/stream/BandcampPlugin.test.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.test.ts
@@ -1,0 +1,60 @@
+import {BandcampPlugin} from '.';
+import {Bandcamp} from '../../rest';
+import spyOn = jest.spyOn;
+import {BandcampSearchResult} from '../../rest/Bandcamp';
+
+describe('Bandcamp plugin tests', () => {
+  let plugin: BandcampPlugin;
+
+  beforeEach(() => {
+    plugin = new BandcampPlugin();
+  });
+
+  describe('find track URLs', () => {
+    const streamQuery = {
+      artist: 'Artist Name',
+      track: 'Track Name'
+    };
+    const trackQuery = 'Track Name';
+    const bandcampSearch = spyOn(Bandcamp, 'search');
+
+    afterEach(() => {
+      bandcampSearch.mockReset();
+    });
+
+    test('finds track', async () => {
+      const matchingSearchResult: BandcampSearchResult = {
+        type: 'track',
+        artist: 'Artist Name',
+        name: 'Track Name',
+        url: null,
+        imageUrl: null,
+        tags: null
+      };
+      bandcampSearch.mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([matchingSearchResult]);
+
+      await expect(plugin.findTrackUrls(streamQuery))
+        .resolves.toEqual([matchingSearchResult]);
+
+      expect(bandcampSearch).toHaveBeenCalledTimes(5);
+      expect(bandcampSearch).toHaveBeenNthCalledWith(1, trackQuery, 0);
+      expect(bandcampSearch).toHaveBeenNthCalledWith(2, trackQuery, 1);
+      expect(bandcampSearch).toHaveBeenNthCalledWith(3, trackQuery, 2);
+      expect(bandcampSearch).toHaveBeenNthCalledWith(4, trackQuery, 3);
+      expect(bandcampSearch).toHaveBeenNthCalledWith(5, trackQuery, 4);
+    });
+
+    test('doesn\'t find tracks', async () => {
+      bandcampSearch.mockResolvedValue([]);
+
+      await expect(plugin.findTrackUrls(streamQuery))
+        .resolves.toEqual([]);
+
+      expect(bandcampSearch).toHaveBeenCalledTimes(5);
+    });
+  });
+});

--- a/packages/core/src/plugins/stream/BandcampPlugin.test.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.test.ts
@@ -1,7 +1,7 @@
-import {BandcampPlugin} from '.';
-import {Bandcamp} from '../../rest';
+import { BandcampPlugin } from '.';
+import { Bandcamp } from '../../rest';
 import spyOn = jest.spyOn;
-import {BandcampSearchResult} from '../../rest/Bandcamp';
+import { BandcampSearchResult } from '../../rest/Bandcamp';
 
 describe('Bandcamp plugin tests', () => {
   let plugin: BandcampPlugin;
@@ -27,9 +27,9 @@ describe('Bandcamp plugin tests', () => {
         type: 'track',
         artist: 'Artist Name',
         name: 'Track Name',
-        url: null,
-        imageUrl: null,
-        tags: null
+        url: 'URL',
+        imageUrl: 'image URL',
+        tags: []
       };
       bandcampSearch.mockResolvedValueOnce([])
         .mockResolvedValueOnce([])

--- a/packages/core/src/plugins/stream/BandcampPlugin.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.ts
@@ -24,7 +24,7 @@ class BandcampPlugin extends StreamProviderPlugin {
         item.type === 'track' &&
         item.artist.toLowerCase() === query.artist.toLowerCase()
       );
-      if (tracks) {
+      if (tracks.length > 0) {
         break;
       }
     }


### PR DESCRIPTION
The Bandcamp plugin aborts the search after the first page of results because of an incorrect check.
I found this bug while writing tests for an improvement/issue in the Bandcamp plugin and thought that it's better to submit it separately.