### PR TITLE
Fix imprecise stream search in the Bandcamp plugin

### DIFF
--- a/packages/core/src/plugins/stream/BandcampPlugin.test.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.test.ts
@@ -16,12 +16,18 @@ describe('Bandcamp plugin tests', () => {
       artist: 'Artist Name',
       track: 'Track Name'
     };
-    const trackQuery = 'Artist Name Track Name';
+    const searchTerm = 'Search term for Bandcamp';
+    // some of the search result attributes are irrelevant for this test case
+    const irrelevantSearchResultAttributes = {
+      url: 'not relevant for this test',
+      imageUrl: 'not relevant for this test',
+      tags: []
+    };
     const bandcampSearch = spyOn(Bandcamp, 'search');
 
     beforeEach(() => {
-      spyOn(plugin, 'createTrackQuery')
-        .mockImplementation(fn(() => trackQuery));
+      spyOn(plugin, 'createSearchTerm')
+        .mockImplementation(fn(() => searchTerm));
       // 'accept all' matcher
       spyOn(plugin, 'createTrackMatcher')
         .mockImplementation(fn(query => () => true));
@@ -36,9 +42,7 @@ describe('Bandcamp plugin tests', () => {
         type: 'track',
         artist: 'Artist Name',
         name: 'Track Name',
-        url: 'URL',
-        imageUrl: 'image URL',
-        tags: []
+        ...irrelevantSearchResultAttributes
       };
       bandcampSearch.mockResolvedValueOnce([])
         .mockResolvedValueOnce([])
@@ -50,11 +54,11 @@ describe('Bandcamp plugin tests', () => {
         .resolves.toEqual([matchingSearchResult]);
 
       expect(bandcampSearch).toHaveBeenCalledTimes(5);
-      expect(bandcampSearch).toHaveBeenNthCalledWith(1, trackQuery, 0);
-      expect(bandcampSearch).toHaveBeenNthCalledWith(2, trackQuery, 1);
-      expect(bandcampSearch).toHaveBeenNthCalledWith(3, trackQuery, 2);
-      expect(bandcampSearch).toHaveBeenNthCalledWith(4, trackQuery, 3);
-      expect(bandcampSearch).toHaveBeenNthCalledWith(5, trackQuery, 4);
+      expect(bandcampSearch).toHaveBeenNthCalledWith(1, searchTerm, 0);
+      expect(bandcampSearch).toHaveBeenNthCalledWith(2, searchTerm, 1);
+      expect(bandcampSearch).toHaveBeenNthCalledWith(3, searchTerm, 2);
+      expect(bandcampSearch).toHaveBeenNthCalledWith(4, searchTerm, 3);
+      expect(bandcampSearch).toHaveBeenNthCalledWith(5, searchTerm, 4);
     });
 
     test('doesn\'t find tracks', async () => {
@@ -67,42 +71,59 @@ describe('Bandcamp plugin tests', () => {
     });
   });
 
-  test('creates track query', () => {
+  test('creates search term', () => {
     const streamQuery = {
       artist: 'Artist Name',
       track: 'Track Name'
     };
-    const trackQuery = plugin.createTrackQuery(streamQuery);
-    expect(trackQuery).toBe('Artist Name Track Name');
+    const searchTerm = plugin.createSearchTerm(streamQuery);
+    expect(searchTerm).toBe('Artist Name Track Name');
   });
 
   test('creates track matcher', () => {
+    // some of the search result attributes are irrelevant for this test case
+    const irrelevantSearchResultAttributes = {
+      url: 'irrelevant for this test',
+      imageUrl: 'irrelevant for this test',
+      tags: []
+    };
     const streamQuery = {
       artist: 'Artist Name',
-      track: 'Track Name'
+      track: 'Track Name',
+      ...irrelevantSearchResultAttributes
     };
     const matcher = plugin.createTrackMatcher(streamQuery);
-    const matchingResult = {
+    const matchingResult: BandcampSearchResult = {
       type: 'track',
       artist: 'Artist Name',
-      name: 'Track Name'
+      name: 'Track Name',
+      ...irrelevantSearchResultAttributes
     };
-    const searchResults = [
+    const searchResults: BandcampSearchResult[] = [
       matchingResult, // first match
       {
-        type: 'album' // type shouldn't match
+        type: 'album', // the 'album' type shouldn't match
+        artist: 'irrelevant for this entry',
+        name: 'irrelevant for this entry',
+        ...irrelevantSearchResultAttributes
       },
       {
-        type: 'artist' // type shouldn't match
+        type: 'artist', // the 'artist' type shouldn't match
+        artist: 'irrelevant for this entry',
+        name: 'irrelevant for this entry',
+        ...irrelevantSearchResultAttributes
       },
       {
         type: 'track',
-        artist: 'Wrong Artist' // artist shouldn't match
+        artist: 'Wrong Artist', // artist shouldn't match
+        name: 'irrelevant for this entry',
+        ...irrelevantSearchResultAttributes
       },
       {
         type: 'track',
         artist: 'Artist Name',
-        name: 'Wrong Title' // track name shouldn't match
+        name: 'Wrong Title', // track name shouldn't match
+        ...irrelevantSearchResultAttributes
       },
       matchingResult // second match
     ];

--- a/packages/core/src/plugins/stream/BandcampPlugin.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.ts
@@ -18,10 +18,10 @@ class BandcampPlugin extends StreamProviderPlugin {
     const limit = 5;
     let tracks: BandcampSearchResult[];
 
-    const trackQuery: string = this.createTrackQuery(query);
+    const searchTerm: string = this.createSearchTerm(query);
     const isMatchingTrack = this.createTrackMatcher(query);
     for (let page = 0; page < limit; page++) {
-      const searchResults = await Bandcamp.search(trackQuery, page);
+      const searchResults = await Bandcamp.search(searchTerm, page);
       tracks = searchResults.filter(isMatchingTrack);
       if (tracks.length > 0) {
         break;
@@ -30,11 +30,11 @@ class BandcampPlugin extends StreamProviderPlugin {
     return tracks;
   }
 
-  createTrackQuery(query: StreamQuery): string {
+  createSearchTerm(query: StreamQuery): string {
     return `${query.artist} ${query.track}`;
   }
 
-  createTrackMatcher(query: StreamQuery): (BandcampSearchResult) => boolean {
+  createTrackMatcher(query: StreamQuery): (item: BandcampSearchResult) => boolean {
     const lowerCaseTrack: string = query.track.toLowerCase();
     const lowerCaseArtist: string = query.artist.toLowerCase();
     return (searchResult) =>

--- a/packages/core/src/plugins/stream/BandcampPlugin.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.ts
@@ -18,17 +18,29 @@ class BandcampPlugin extends StreamProviderPlugin {
     const limit = 5;
     let tracks: BandcampSearchResult[];
 
+    const trackQuery: string = this.createTrackQuery(query);
+    const isMatchingTrack = this.createTrackMatcher(query);
     for (let page = 0; page < limit; page++) {
-      const searchResults = await Bandcamp.search(query.track, page);
-      tracks = searchResults.filter(item =>
-        item.type === 'track' &&
-        item.artist.toLowerCase() === query.artist.toLowerCase()
-      );
+      const searchResults = await Bandcamp.search(trackQuery, page);
+      tracks = searchResults.filter(isMatchingTrack);
       if (tracks.length > 0) {
         break;
       }
     }
     return tracks;
+  }
+
+  createTrackQuery(query: StreamQuery): string {
+    return `${query.artist} ${query.track}`;
+  }
+
+  createTrackMatcher(query: StreamQuery): (BandcampSearchResult) => boolean {
+    const lowerCaseTrack: string = query.track.toLowerCase();
+    const lowerCaseArtist: string = query.artist.toLowerCase();
+    return (searchResult) =>
+      searchResult.type === 'track' &&
+      searchResult.artist.toLowerCase() === lowerCaseArtist &&
+      searchResult.name.toLowerCase() === lowerCaseTrack;
   }
 
   resultToStream(result: BandcampSearchResult, stream: string, duration: number): StreamData {


### PR DESCRIPTION
When the name of a track was very simple, the actual search match could be on a page higher than the configured maximum. This caused the search to fail and the track wouldn't be played. The amount of search results can be greatly reduced by simply adding the artist name to the query.

To reproduce the issue: 
* search for "somali yacht club sun"
* select the album "The Sun" by "Somali Yacht Club"
* attempt to play the first track: "Loom". Playing will fail, because when searching for "Loom" alone, the actual search result is on a page higher than 5 (the currently hardcoded limit).

The search could be additionally improved by searching only for tracks (and not artiststs and albums) when attempting to find streams, but that would require extending the bandcamp scraper module with this kind of functionality. Yet it shouldn't be too hard.

Notes: 
* The reason I extracted 2 blocks of code to separate methods is to allow easier simpler test setup and to increase the coverage.
* This PR is based on #1548 and includes those commits. The diff should be greatly reduced if #1548 is approved and merged to master.