### PR TITLE
Make Bandcamp search result matching more robust

### DIFF
--- a/packages/core/src/plugins/stream/BandcampPlugin.test.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.test.ts
@@ -87,9 +87,11 @@ describe('Bandcamp plugin tests', () => {
       imageUrl: 'irrelevant for this test',
       tags: []
     };
+    const normalizeForMatching = spyOn(plugin, 'normalizeForMatching');
+    normalizeForMatching.mockImplementation(term => term);
     const streamQuery = {
-      artist: '  Artist Name',
-      track: 'Track Name  ',
+      artist: 'Artist Name',
+      track: 'Track Name',
       ...irrelevantSearchResultAttributes
     };
     const matcher = plugin.createTrackMatcher(streamQuery);

--- a/packages/core/src/plugins/stream/BandcampPlugin.test.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.test.ts
@@ -1,8 +1,8 @@
 import { BandcampPlugin } from '.';
-import fn = jest.fn;
 import { Bandcamp } from '../../rest';
-import spyOn = jest.spyOn;
 import { BandcampSearchResult } from '../../rest/Bandcamp';
+import fn = jest.fn;
+import spyOn = jest.spyOn;
 
 describe('Bandcamp plugin tests', () => {
   let plugin: BandcampPlugin;
@@ -88,8 +88,8 @@ describe('Bandcamp plugin tests', () => {
       tags: []
     };
     const streamQuery = {
-      artist: 'Artist Name',
-      track: 'Track Name',
+      artist: '  Artist Name',
+      track: 'Track Name  ',
       ...irrelevantSearchResultAttributes
     };
     const matcher = plugin.createTrackMatcher(streamQuery);
@@ -129,5 +129,12 @@ describe('Bandcamp plugin tests', () => {
     ];
     const tracks = searchResults.filter(matcher);
     expect(tracks).toEqual([matchingResult, matchingResult]);
+  });
+
+  test('normalizes value for matching search results', () => {
+    // mixed case search term padded with spaces
+    const termToNormalize = '   Search Term   ';
+    const normalizedTerm = plugin.normalizeForMatching(termToNormalize);
+    expect(normalizedTerm).toEqual('search term');
   });
 });

--- a/packages/core/src/plugins/stream/BandcampPlugin.test.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.test.ts
@@ -131,7 +131,7 @@ describe('Bandcamp plugin tests', () => {
     expect(tracks).toEqual([matchingResult, matchingResult]);
   });
 
-  test('normalizes value for matching search results', () => {
+  test('normalizeForMatching trims and converts the term to lowercase', () => {
     // mixed case search term padded with spaces
     const termToNormalize = '   Search Term   ';
     const normalizedTerm = plugin.normalizeForMatching(termToNormalize);

--- a/packages/core/src/plugins/stream/BandcampPlugin.ts
+++ b/packages/core/src/plugins/stream/BandcampPlugin.ts
@@ -35,12 +35,16 @@ class BandcampPlugin extends StreamProviderPlugin {
   }
 
   createTrackMatcher(query: StreamQuery): (item: BandcampSearchResult) => boolean {
-    const lowerCaseTrack: string = query.track.toLowerCase();
-    const lowerCaseArtist: string = query.artist.toLowerCase();
+    const normalizedTrack: string = this.normalizeForMatching(query.track);
+    const normalizedArtist: string = this.normalizeForMatching(query.artist);
     return (searchResult) =>
       searchResult.type === 'track' &&
-      searchResult.artist.toLowerCase() === lowerCaseArtist &&
-      searchResult.name.toLowerCase() === lowerCaseTrack;
+      this.normalizeForMatching(searchResult.artist) === normalizedArtist &&
+      this.normalizeForMatching(searchResult.name) === normalizedTrack;
+  }
+
+  normalizeForMatching(term: string): string {
+    return term.trim().toLowerCase();
   }
 
   resultToStream(result: BandcampSearchResult, stream: string, duration: number): StreamData {


### PR DESCRIPTION
Some metadata providers like Discogs provide track names which include trailing spaces which caused the search to fail. Removing leading and trailing spaces from track and artist names allows us to find any previously missed matches.

To reproduce the issue:
* setup:
  * metadata provider: Discogs
  * stream provider: Bandcamp
* search for "somali sun", select "The Sun" by "Somali Yacht Club"
* no streams on Bandcamp match because all tracks contain trailing spaces and the matching is too strict