### PR TITLE
Fix 1576 : Play counts not aligned (artist popular tracks)

### DIFF
--- a/packages/app/app/components/ArtistView/PopularTracks/index.tsx
+++ b/packages/app/app/components/ArtistView/PopularTracks/index.tsx
@@ -75,7 +75,7 @@ const PopularTracks: React.FC<PopularTracksProps> = ({
           handleAddAll={handleAddAll}
           t={t}
         />
-        <table className={styles.popular_tracks_table}>
+        <table>
           <thead>
             <tr>
               <th>

--- a/packages/app/app/components/ArtistView/PopularTracks/styles.scss
+++ b/packages/app/app/components/ArtistView/PopularTracks/styles.scss
@@ -26,12 +26,6 @@
       background: lighten($background, 5%);
     }
   }
-
-  .popular_tracks_table {
-    th:last-child {
-      text-align: right;
-    }
-  }
 }
 
 .add_button {

--- a/packages/app/app/containers/ArtistViewContainer/__snapshots__/ArtistViewContainer.test.tsx.snap
+++ b/packages/app/app/containers/ArtistViewContainer/__snapshots__/ArtistViewContainer.test.tsx.snap
@@ -110,9 +110,7 @@ exports[`Artist view container should display an artist 1`] = `
               />
                Add all
             </a>
-            <table
-              class="popular_tracks_table"
-            >
+            <table>
               <thead>
                 <tr>
                   <th>


### PR DESCRIPTION
Great project 👏 ! 
I start with a simple PR but I'd like to do more and discover the codebase.

--

Remove text-align:right on popular_tracks_table header to fix vertical alignment with table-rows

Fix #1576 

Here is what I have changed :
![image](https://github.com/nukeop/nuclear/assets/2821522/7e144ad3-f806-4331-bebf-b965097900be)
