### PR TITLE
Fix #1503: Fix skip track buttons on mac devices

### DIFF
--- a/packages/app/app/containers/ShortcutsContainer/ShortcutsContainer.test.tsx
+++ b/packages/app/app/containers/ShortcutsContainer/ShortcutsContainer.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent} from '@testing-library/react';
+import React from 'react';
+
+import ShortcutsContainer from '.';
+import { isMac } from '../../hooks/usePlatform';
+import { AnyProps, setupI18Next, mountComponent } from '../../../test/testUtils';
+import { buildStoreState } from '../../../test/storeBuilders';
+
+describe('Shortcut container', () => {
+  beforeAll(() => {
+    setupI18Next();
+  });
+
+  it('should start playing the current track when the f8 key is clicked on mac', async () => {
+    const { store } = mountShortcuts();
+    fireEvent.keyDown(document.body, {key: 'F8', code: 'F8', which: 119});
+    const state = store.getState();
+    if (isMac()){
+      expect(state.player.playbackStatus).toBe('PLAYING');
+    } else {
+      expect(state.player.playbackStatus).toBe('PAUSED');
+    }
+  });
+
+  it('should pause the current track when the f8 key is clicked and the song is currently playing on mac', async () => {
+    const { store } = mountShortcuts({
+      player: {
+        playbackStatus: 'PLAYING'
+      }
+    });
+    fireEvent.keyDown(document.body, {key: 'F8', code: 'F8', which: 119});
+    const state = store.getState();
+    if (isMac()){
+      expect(state.player.playbackStatus).toBe('PAUSED');
+    } else {
+      expect(state.player.playbackStatus).toBe('PLAYING');
+    }
+  });
+
+  it('should skip to the next track when the f9 is clicked on mac', async () => {
+    const { store } = mountShortcuts();
+    fireEvent.keyDown(document.body, {key: 'F9', code: 'F9', which: 120});
+    const state = store.getState();
+    if (isMac()){
+      expect(state.queue.currentSong).toBe(1);
+    } else {
+      expect(state.queue.currentSong).toBe(0);
+    }
+        
+  });
+
+  it('should skip to the previous track when the f7 is clicked on mac', async () => {
+    const { store } = mountShortcuts({
+      queue: {
+        currentSong: 1,
+        queueItems: [{
+          artist: 'test artist 1',
+          name: 'test track 1',
+          streams: [{
+            duration: 300,
+            title: 'test track 1',
+            skipSegments: [],
+            stream: 'stream URL 1'
+          }]
+        }, {
+          artist: 'test artist 2',
+          name: 'test track 2',
+          streams: [{
+            duration: 300,
+            title: 'test track 2',
+            skipSegments: [],
+            stream: 'stream URL 2'
+          }]
+        }]
+      },
+      player: {
+        seek: 0
+      }
+    });
+    fireEvent.keyDown(document.body, {key: 'F7', code: 'F7', which: 118});
+    const state = store.getState();
+    if (isMac()){
+      expect(state.player.seek).toBe(0);
+      expect(state.queue.currentSong).toBe(0);
+    } else {
+      expect(state.player.seek).toBe(0);
+      expect(state.queue.currentSong).toBe(1);
+    }
+
+  });
+
+  const mountShortcuts = (initialStore?: AnyProps) => {
+    return mountComponent(
+      <ShortcutsContainer />,
+      ['/'],
+      {
+        ...buildStoreState()
+          .withTracksInPlayQueue()
+          .withSettings({
+            trackDuration: true,
+            skipSponsorblock: true
+          })
+          .build(),
+        ...initialStore
+      }
+    );
+  };
+});

--- a/packages/app/app/containers/ShortcutsContainer/ShortcutsContainer.test.tsx
+++ b/packages/app/app/containers/ShortcutsContainer/ShortcutsContainer.test.tsx
@@ -6,23 +6,23 @@ import { isMac } from '../../hooks/usePlatform';
 import { AnyProps, setupI18Next, mountComponent } from '../../../test/testUtils';
 import { buildStoreState } from '../../../test/storeBuilders';
 
+jest.mock('../../hooks/usePlatform');
+
 describe('Shortcut container', () => {
   beforeAll(() => {
     setupI18Next();
   });
 
   it('should start playing the current track when the f8 key is clicked on mac', async () => {
+    (isMac as jest.Mock).mockReturnValueOnce(true);
     const { store } = mountShortcuts();
     fireEvent.keyDown(document.body, {key: 'F8', code: 'F8', which: 119});
     const state = store.getState();
-    if (isMac()){
-      expect(state.player.playbackStatus).toBe('PLAYING');
-    } else {
-      expect(state.player.playbackStatus).toBe('PAUSED');
-    }
+    expect(state.player.playbackStatus).toBe('PLAYING');
   });
 
   it('should pause the current track when the f8 key is clicked and the song is currently playing on mac', async () => {
+    (isMac as jest.Mock).mockReturnValueOnce(true);
     const { store } = mountShortcuts({
       player: {
         playbackStatus: 'PLAYING'
@@ -30,26 +30,19 @@ describe('Shortcut container', () => {
     });
     fireEvent.keyDown(document.body, {key: 'F8', code: 'F8', which: 119});
     const state = store.getState();
-    if (isMac()){
-      expect(state.player.playbackStatus).toBe('PAUSED');
-    } else {
-      expect(state.player.playbackStatus).toBe('PLAYING');
-    }
+    expect(state.player.playbackStatus).toBe('PAUSED');
   });
 
   it('should skip to the next track when the f9 is clicked on mac', async () => {
+    (isMac as jest.Mock).mockReturnValueOnce(true);
     const { store } = mountShortcuts();
     fireEvent.keyDown(document.body, {key: 'F9', code: 'F9', which: 120});
     const state = store.getState();
-    if (isMac()){
-      expect(state.queue.currentSong).toBe(1);
-    } else {
-      expect(state.queue.currentSong).toBe(0);
-    }
-        
+    expect(state.queue.currentSong).toBe(1);
   });
 
   it('should skip to the previous track when the f7 is clicked on mac', async () => {
+    (isMac as jest.Mock).mockReturnValueOnce(true);
     const { store } = mountShortcuts({
       queue: {
         currentSong: 1,
@@ -79,14 +72,71 @@ describe('Shortcut container', () => {
     });
     fireEvent.keyDown(document.body, {key: 'F7', code: 'F7', which: 118});
     const state = store.getState();
-    if (isMac()){
-      expect(state.player.seek).toBe(0);
-      expect(state.queue.currentSong).toBe(0);
-    } else {
-      expect(state.player.seek).toBe(0);
-      expect(state.queue.currentSong).toBe(1);
-    }
+    expect(state.player.seek).toBe(0);
+    expect(state.queue.currentSong).toBe(0);
+  });
 
+  it('should not start playing the current track when the f8 key is clicked and the os is not mac', async () => {
+    (isMac as jest.Mock).mockReturnValueOnce(false);
+    const { store } = mountShortcuts();
+    fireEvent.keyDown(document.body, {key: 'F8', code: 'F8', which: 119});
+    const state = store.getState();
+    expect(state.player.playbackStatus).toBe('PAUSED');
+  });
+
+  it('should not pause the current track when the f8 key is clicked and the song is currently playing, when the os is not mac', async () => {
+    (isMac as jest.Mock).mockReturnValueOnce(false);
+    const { store } = mountShortcuts({
+      player: {
+        playbackStatus: 'PLAYING'
+      }
+    });
+    fireEvent.keyDown(document.body, {key: 'F8', code: 'F8', which: 119});
+    const state = store.getState();
+    expect(state.player.playbackStatus).toBe('PLAYING');
+  });
+
+  it('should not skip to the next track when f9 is clicked and the os is not mac', async () => {
+    (isMac as jest.Mock).mockReturnValueOnce(false);
+    const { store } = mountShortcuts();
+    fireEvent.keyDown(document.body, {key: 'F9', code: 'F9', which: 120});
+    const state = store.getState();
+    expect(state.queue.currentSong).toBe(0);
+  });
+
+  it('should not skip to the previous track when f7 is clicked and the os is not mac', async () => {
+    (isMac as jest.Mock).mockReturnValueOnce(false);
+    const { store } = mountShortcuts({
+      queue: {
+        currentSong: 1,
+        queueItems: [{
+          artist: 'test artist 1',
+          name: 'test track 1',
+          streams: [{
+            duration: 300,
+            title: 'test track 1',
+            skipSegments: [],
+            stream: 'stream URL 1'
+          }]
+        }, {
+          artist: 'test artist 2',
+          name: 'test track 2',
+          streams: [{
+            duration: 300,
+            title: 'test track 2',
+            skipSegments: [],
+            stream: 'stream URL 2'
+          }]
+        }]
+      },
+      player: {
+        seek: 0
+      }
+    });
+    fireEvent.keyDown(document.body, {key: 'F7', code: 'F7', which: 118});
+    const state = store.getState();
+    expect(state.player.seek).toBe(0);
+    expect(state.queue.currentSong).toBe(1);
   });
 
   const mountShortcuts = (initialStore?: AnyProps) => {

--- a/packages/app/app/containers/ShortcutsContainer/index.js
+++ b/packages/app/app/containers/ShortcutsContainer/index.js
@@ -119,8 +119,6 @@ class Shortcuts extends React.Component {
       179: 'MediaPlayPause',
       177: 'MediaTrackPrevious',
       176: 'MediaTrackNext'
-
-
     });
 
     Mousetrap.bind('space', this.handleSpaceBar);

--- a/packages/app/app/containers/ShortcutsContainer/index.js
+++ b/packages/app/app/containers/ShortcutsContainer/index.js
@@ -6,6 +6,7 @@ import * as Mousetrap from 'mousetrap';
 import Sound from 'react-hifi';
 import _ from 'lodash';
 import { compose } from 'recompose';
+import { isMac } from '../../hooks/usePlatform';
 
 import * as PlayerActions from '../../actions/player';
 import * as QueueActions from '../../actions/queue';
@@ -137,6 +138,11 @@ class Shortcuts extends React.Component {
     Mousetrap.bind('MediaPlayPause',  this.handleSpaceBar);
     Mousetrap.bind('MediaTrackPrevious',  this.props.actions.previousSong);
     Mousetrap.bind('MediaTrackNext',  this.props.actions.nextSong);
+    if (isMac()){
+      Mousetrap.bind('f7', this.props.actions.previousSong);
+      Mousetrap.bind('f8', this.handleSpaceBar);
+      Mousetrap.bind('f9', this.props.actions.nextSong);
+    }
   }
 
   componentWillUnmount() {
@@ -157,6 +163,9 @@ class Shortcuts extends React.Component {
       'command+top',
       'ctrl+down',
       'command+down',
+      'f7',
+      'f8',
+      'f9',
       'f12',
       'command+i',
       'MediaPlayPause',


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->
In issue #1503 the the issuer noted that the usual keyboard buttons to switch to the next track or previous (or play/pause) do not work. The buttons they are speaking of are shown here https://www.macworld.com/wp-content/uploads/2023/01/mac-keyboard-play-pause-100837087-orig.jpg?quality=50&strip=all&w=1024. From searching online it appears that all apple keyboards include these symbols to suggest that the f7, f8, and f9 keys have functionalities to switch to the previous track, play/pause, and switch the next track respectively.

This change adds these shortcuts for only mac devices, since this functionality is only suggested prominently on mac devices.