### PR TITLE
Fix/1585: "Popular Tracks" is not translated

### DIFF
--- a/packages/app/app/components/ArtistView/PopularTracks/index.tsx
+++ b/packages/app/app/components/ArtistView/PopularTracks/index.tsx
@@ -70,7 +70,7 @@ const PopularTracks: React.FC<PopularTracksProps> = ({
         styles.popular_tracks_container,
         trackRowStyles.tracks_container
       )}>
-        <div className={styles.header}>Popular tracks </div>
+        <div className={styles.header}>{t('popular-tracks')}</div>
         <AddAllButton 
           handleAddAll={handleAddAll}
           t={t}

--- a/packages/app/app/containers/ArtistViewContainer/__snapshots__/ArtistViewContainer.test.tsx.snap
+++ b/packages/app/app/containers/ArtistViewContainer/__snapshots__/ArtistViewContainer.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`Artist view container should display an artist 1`] = `
             <div
               class="header"
             >
-              Popular tracks 
+              Popular tracks
             </div>
             <a
               aria-label="Add all"

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -46,7 +46,8 @@
     "queue": "Add all tracks to queue",
     "similar": "Similar artists",
     "title": "Title",
-    "tour": "On tour"
+    "tour": "On tour",
+    "popular-tracks": "Popular tracks"
   },
   "dashboard": {
     "add-all": "Add all",


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->

Added Popular Tracks to the en.json file and changed the PopularTracks component to use the translation.
