### PR TITLE
Fix #1554: Center Play/Pause Button

### DIFF
--- a/packages/ui/lib/components/PlayerButton/styles.scss
+++ b/packages/ui/lib/components/PlayerButton/styles.scss
@@ -3,6 +3,7 @@
   border: none;
   cursor: pointer;
   outline: none;
+  margin-right: 4px;
 
   &.disabled {
     opacity: 0.2;


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->
Fixes #1544
Adds a right margin of 4px to the player button class which successfully centers each icon (pause, play, or loading). Although a previous comment highlighted that each icon was off center by a varying amount, from my inspection they are all off by the same amount, so the same margin can be applied to all of them.  