### PR TITLE
Solved issue 1147

### DIFF
--- a/packages/app/app/actions/search.ts
+++ b/packages/app/app/actions/search.ts
@@ -285,11 +285,11 @@ export const artistInfoSearchByName = (artistName: string, history: History) => 
   const selectedProvider = getSelectedMetaProvider(getState);
   const { settings } = getState();
   try {
-    _.invoke(history, 'push', '/artist/loading');
+    history.push('/artist/loading');
     dispatch(SearchActions.artistInfoStart('loading'));
     const artistDetails = await selectedProvider.fetchArtistDetailsByName(artistName);
     dispatch(SearchActions.artistInfoSuccess(artistDetails.id, artistDetails));
-    _.invoke(history, 'push', `/artist/${artistDetails.id}`);
+    history.replace(`/artist/${artistDetails.id}`);
   } catch (e) {
     logger.error(e);
     dispatch(error(


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->
This solves issue https://github.com/nukeop/nuclear/issues/1147. The issue was caused by a problem managing the history object. Instead of replacing the actual loading page position by the rendered artist view, is was being pushed, causing the navigation buttons to move to infinite loading screens. 

I could not find tests for the functions that implement the search artists logic. If they exist, I am sure that you could guide me to them.