### PR TITLE
Fixes issue mentioned in #1569. Unable to play file until app restart

### DIFF
--- a/packages/app/app/actions/local.ts
+++ b/packages/app/app/actions/local.ts
@@ -42,7 +42,10 @@ export const localLibraryActions = {
   removeLocalFolder: createAction(LocalLibrary.REMOVE_LOCAL_FOLDER, (folder: string[]) => folder),
   scanLocalFolders: VoidAction(LocalLibrary.SCAN_LOCAL_FOLDERS),
   scanLocalFoldersProgress: createAction(LocalLibrary.SCAN_LOCAL_FOLDERS_PROGRESS, (scanProgress: number, scanTotal: number) => ({ scanProgress, scanTotal })),
-  scanLocalFoldersSuccess: createAction(LocalLibrary.SCAN_LOCAL_FOLDERS_SUCCESS, (payload: Track[]) => payload),
+  scanLocalFoldersSuccess: createAction(LocalLibrary.SCAN_LOCAL_FOLDERS_SUCCESS, (payload: Track[]) => {
+    const tracks = Array.isArray(payload) ? payload : Object.values(payload);
+    return tracks;
+  }),
   scanLocalFoldersFailure: VoidAction(LocalLibrary.SCAN_LOCAL_FOLDERS_FAILURE),
   updateFilter: createAction(LocalLibrary.UPDATE_LOCAL_FILTER, (event: { target: { value: string } }) => ({ filter: event.target.value })),
   updateLocalSort: createAction(LocalLibrary.UPDATE_LOCAL_SORT, (sortBy, column, direction) => ({


### PR DESCRIPTION
I assumed it's not needed to make this an issue of its own but will do so if needed.

Basically, when trying to play recently added files to the queue the reducer for the local state expects an array of Track objects per a Typescript type assertion, this is important because the queue action tries to run find on this array. Problem is that when the tracks are first loaded they appear as an object with key-value pairs rather than an array:

![image](https://github.com/nukeop/nuclear/assets/48533334/56f539f4-ed24-4915-a813-b3b1ec4a6986)

This is a quick fix on that.