### PR TITLE
Fixed windows build issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21594,10 +21594,11 @@
       "dev": true
     },
     "node_modules/deasync": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.28.tgz",
-      "integrity": "sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.30.tgz",
+      "integrity": "sha512-OaAjvEQuQ9tJsKG4oHO9nV1UHTwb2Qc2+fadB0VeVtD0Z9wiG1XPGLJ4W3aLhAoQSYTaLROFRbd5X20Dkzf7MQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^1.7.1"
@@ -48650,7 +48651,7 @@
         "classnames": "^2.2.6",
         "d3-drag": "^1.2.3",
         "d3-selection": "^1.4.0",
-        "deasync": "^0.1.28",
+        "deasync": "^0.1.30",
         "dotenv": "^8.2.0",
         "electron": "^12.1.0",
         "electron-timber": "^0.5.1",
@@ -48831,7 +48832,7 @@
         "prism-media": "^1.3.5",
         "reflect-metadata": "^0.1.13",
         "rotating-file-stream": "^2.0.2",
-        "sqlite3": "^5.1.7",
+        "sqlite3": "^5.1.6",
         "stream-filter": "^2.1.0",
         "stream-reduce": "^1.0.3",
         "swagger-spec-express": "^2.0.20",
@@ -53417,7 +53418,7 @@
         "css-loader": "^5.2.7",
         "d3-drag": "^1.2.3",
         "d3-selection": "^1.4.0",
-        "deasync": "^0.1.28",
+        "deasync": "^0.1.30",
         "dotenv": "^8.2.0",
         "electron": "^12.1.0",
         "electron-timber": "^0.5.1",
@@ -53588,7 +53589,7 @@
         "reflect-metadata": "^0.1.13",
         "rotating-file-stream": "^2.0.2",
         "shx": "^0.3.3",
-        "sqlite3": "^5.1.7",
+        "sqlite3": "^5.1.6",
         "stream-filter": "^2.1.0",
         "stream-reduce": "^1.0.3",
         "swagger-spec-express": "^2.0.20",
@@ -66475,9 +66476,9 @@
       "dev": true
     },
     "deasync": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.28.tgz",
-      "integrity": "sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.30.tgz",
+      "integrity": "sha512-OaAjvEQuQ9tJsKG4oHO9nV1UHTwb2Qc2+fadB0VeVtD0Z9wiG1XPGLJ4W3aLhAoQSYTaLROFRbd5X20Dkzf7MQ==",
       "requires": {
         "bindings": "^1.5.0",
         "node-addon-api": "^1.7.1"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -46,7 +46,7 @@
     "classnames": "^2.2.6",
     "d3-drag": "^1.2.3",
     "d3-selection": "^1.4.0",
-    "deasync": "^0.1.28",
+    "deasync": "^0.1.30",
     "dotenv": "^8.2.0",
     "electron": "^12.1.0",
     "electron-timber": "^0.5.1",


### PR DESCRIPTION
The problem was occurring because of this node update:
https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2

This issue is fixed in `0.1.30` version of `deasync` package ([commit](https://github.com/abbr/deasync/commit/5ed34d2a4bc22a9c30547737c7fcd1dac37009c0))

Closes #1622 