### PR TITLE
Add Tailwind to the ui package

### DIFF
--- a/packages/ui/lib/common.scss
+++ b/packages/ui/lib/common.scss
@@ -1,3 +1,7 @@
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
+
 $bgdarker: #1f212d;
 $bgdark: #2c2e3a;
 $bgdefault: #424557;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,7 +51,7 @@
 		"@types/react-measure": "^2.0.6",
 		"@types/react-table": "^7.7.16",
 		"babel-eslint": "^10.0.3",
-		"babel-loader": "^8.1.0",
+		 "babel-loader": "^8.1.0",
 		"copyfiles": "^2.2.0",
 		"css-loader": "^5.2.7",
 		"eslint": "^7.18.0",
@@ -66,7 +66,10 @@
 		"ts-jest": "^27.1.3",
 		"ts-loader": "^8.0.3",
 		"ts-node": "^10.7.0",
-		"typescript": "^4.2.4"
+		"typescript": "^4.2.4",
+		"tailwindcss": "^3.0.23",
+		"postcss": "^8.4.6",
+		"autoprefixer": "^10.4.2"
 	},
 	"dependencies": {
 		"@nuclear/core": "^0.6.31",

--- a/packages/ui/postcss.config.ts
+++ b/packages/ui/postcss.config.ts
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -1,0 +1,15 @@
+import { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
Add Tailwind CSS to the `ui` package while preserving existing functionality implemented with Semantic UI for React.

* **Dependencies**: Add Tailwind CSS, PostCSS, and Autoprefixer as dependencies in `packages/ui/package.json`.
* **Configuration**: Add `tailwind.config.ts` file to configure Tailwind CSS and `postcss.config.ts` file to include Tailwind CSS and Autoprefixer as PostCSS plugins.
* **Styles**: Update `packages/ui/lib/common.scss` to import Tailwind CSS base, components, and utilities.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nukeop/nuclear/tree/master?shareId=df39a9f9-a419-4c70-9743-b99aef966446).