### PR TITLE
Block auxiliary clicks

### DIFF
--- a/packages/app/app/App.js
+++ b/packages/app/app/App.js
@@ -67,9 +67,16 @@ class App extends React.PureComponent {
 
     this.updateConnectivityStatus(navigator.onLine);
     window.addEventListener('online', () => this.updateConnectivityStatus(true));
-    window.addEventListener('offline', () => this.updateConnectivityStatus(false)); 
+    window.addEventListener('offline', () => this.updateConnectivityStatus(false));
+    window.addEventListener('auxclick', this.blockMiddleClick);
   }
 
+  blockMiddleClick = (e) => {
+    // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+    if (e.button === 1) {
+      e.preventDefault();
+    }
+  } 
   updateConnectivityStatus = (isConnected) => {
     this.props.actions.changeConnectivity(isConnected);
   }


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->
Fixes #1619

I've decided to block the event application-wide, in case there would be other places the bug would would reproduce.
