### PR TITLE
Fix download pausing/resume click behaviour

### DIFF
--- a/packages/app/app/actions/downloads.ts
+++ b/packages/app/app/actions/downloads.ts
@@ -108,12 +108,14 @@ export const onDownloadProgress = createStandardAction(DownloadActionTypes.DOWNL
       propertyName: 'completion',
       value: progress
     });
-  
-    payload = changePropertyForItem({
-      downloads: payload,
-      uuid,
-      value: progress < 1 ? DownloadStatus.STARTED : DownloadStatus.FINISHED
-    });
+    if (progress >= 1) {
+      payload = changePropertyForItem({
+        downloads: payload,
+        uuid,
+        value: DownloadStatus.FINISHED
+      });
+    }
+    
   
     return {
       payload

--- a/packages/main/src/controllers/download.ts
+++ b/packages/main/src/controllers/download.ts
@@ -59,6 +59,7 @@ class DownloadIpcCtrl {
       if (downloadRef) {
         if (downloadRef.ref.canResume()) {
           downloadRef.ref.resume();
+          this.window?.send(IpcEvents.DOWNLOAD_STARTED, uuid);
           return;
         }
         this.downloadItems = this.downloadItems.filter((item => item.uuid === uuid));
@@ -80,6 +81,7 @@ class DownloadIpcCtrl {
           this.downloadItems = this.downloadItems.filter((item) => item.uuid !== uuid);
           this.downloadItems.push({ uuid, ref: item });
           this.logger.log(`Download started: ${filename}`);
+          this.window?.send(IpcEvents.DOWNLOAD_STARTED, uuid);
         },
         onProgress: (progress) => {
           this.window.send(IpcEvents.DOWNLOAD_PROGRESS, {


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->

Fixes #1712 

I simply chose to move a responsability out of the Download Progress Action back to the ipc controller.