### PR TITLE
Bug/1151: Fix artist image display consistency across search and artist view

### DIFF
--- a/packages/core/src/plugins/meta/audius.ts
+++ b/packages/core/src/plugins/meta/audius.ts
@@ -94,7 +94,7 @@ class AudiusMetaProvider extends MetaProvider {
       onTour: hasLastFmArtist ? lastFmInfo.ontour === '1' : false,
       coverImage,
       thumb,
-      images: [],
+      images: [coverImage, thumb],
       topTracks: _.map(ArtistTracks, (track) => ({
         name: track.title,
         title: track.title,


### PR DESCRIPTION
Fixes Issue: [https://github.com/nukeop/nuclear/issues/1151]

This PR addresses an inconsistency in artist image display between the search results and the individual artist view. Previously, the artist's picture was visible in search results but not on the artist's dedicated page. The solution implements a fallback mechanism to reuse the background image when only one image is available.


original search result: (have thumbnail displayed)

![image](https://github.com/user-attachments/assets/3ae0c2b6-1bda-411b-993f-f832b41b15fc)

![image](https://github.com/user-attachments/assets/3ec82897-8195-42e0-84b3-e0d39854056c)

after modify the code (search page):

![image](https://github.com/user-attachments/assets/bde4426c-36ca-4f36-8639-cada4d0789ef)

Artist page:
![image](https://github.com/user-attachments/assets/ff78a6f9-5e2e-488e-b140-09ab8e40ab00)


