### PR TITLE
Fix lower part album text disappear issue

### DIFF
--- a/packages/app/app/components/AlbumView/styles.scss
+++ b/packages/app/app/components/AlbumView/styles.scss
@@ -74,12 +74,16 @@
         .album_title {
           display: flex;
           flex-direction: row;
-
+          align-items: center;
+  
           .album_text {
             font-size: 32px;
-            line-height: 32px;
-            flex: 1;
-            @include ellipsis;
+            line-height: 1.2;
+            max-width: calc(100% - 50px);
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
           }
         }
 


### PR DESCRIPTION
## Description  
This PR addresses the styling inconsistencies reported in [Issue #1670](https://github.com/nukeop/nuclear/issues/1670) for the `AlbumView` component. The updates ensure that the album titles are properly aligned and that the text truncation behavior is consistent across different displays.

## Changes Made  
1. **Updated Album Title Alignment:**  
   - Added `align-items: center;` to ensure vertical centering in the album title display.
   
2. **Improved Text Truncation:**  
   - Implemented `-webkit-line-clamp: 2;` to enable ellipsis after two lines.
   - Adjusted `max-width` to `calc(100% - 50px);` ensuring proper text wrapping and visibility.

3. **CSS Property Adjustments:**  
   - Updated `line-height` for `.album_text` to improve readability and spacing.
   
  ## Screenshots
**Before Changes:**  
![image](https://github.com/user-attachments/assets/2839fe34-66c0-4843-a5fd-7aa85da30802)
**After Changes:**  
![image](https://github.com/user-attachments/assets/f1f4c086-790e-4af1-bd23-82f4632c94ce)

