### PR TITLE
Fix/1670 - Lower part album text disappear issue

### DIFF
--- a/packages/app/app/components/AlbumView/styles.scss
+++ b/packages/app/app/components/AlbumView/styles.scss
@@ -75,7 +75,7 @@
           display: flex;
           flex-direction: row;
           align-items: center;
-  
+
           .album_text {
             font-size: 32px;
             line-height: 1.2;
@@ -83,7 +83,6 @@
             @include ellipsis;
           }
         }
- 
 
         .album_artist {
           margin: 1rem 0;

--- a/packages/app/app/components/AlbumView/styles.scss
+++ b/packages/app/app/components/AlbumView/styles.scss
@@ -74,12 +74,16 @@
         .album_title {
           display: flex;
           flex-direction: row;
-
+          align-items: center;
+  
           .album_text {
             font-size: 32px;
-            line-height: 32px;
-            flex: 1;
-            @include ellipsis;
+            line-height: 1.2;
+            max-width: calc(100% - 50px);
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
           }
         }
 

--- a/packages/app/app/components/AlbumView/styles.scss
+++ b/packages/app/app/components/AlbumView/styles.scss
@@ -79,13 +79,11 @@
           .album_text {
             font-size: 32px;
             line-height: 1.2;
-            max-width: calc(100% - 50px);
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            -webkit-box-orient: vertical;
-            overflow: hidden;
+            flex: 1;
+            @include ellipsis;
           }
         }
+ 
 
         .album_artist {
           margin: 1rem 0;


### PR DESCRIPTION
## Description  
This PR addresses the styling inconsistencies reported in [Issue #1670](https://github.com/nukeop/nuclear/issues/1670) for the `AlbumView` component. The updates ensure that the album titles are properly aligned and that the text truncation behavior is consistent across different displays.

## Changes Made  
1. **Updated Album Title Alignment:**  
   - Added `align-items: center;` to ensure vertical centering in the album title display.

2. **CSS Property Adjustments:**  
   - Updated `line-height` for `.album_text` to improve readability and spacing.
   
## Screenshots
**Before Changes:**  
![image](https://github.com/user-attachments/assets/5a5554be-f22b-4e37-afa9-88a95ba49948)

**After Changes: (Now the letter with descender like "g", "y" are visible)**  
<img width="721" alt="Screenshot 2024-10-16 at 5 21 44 PM" src="https://github.com/user-attachments/assets/09d81452-0881-4e87-8802-a61da786cac8">

## Testing
- Run the linter and passed
- Run the npm test and passed
