### PR TITLE
Skip looking for tracks for queue items in error

### DIFF
--- a/packages/app/app/containers/PlayerBarContainer/hooks.ts
+++ b/packages/app/app/containers/PlayerBarContainer/hooks.ts
@@ -255,17 +255,15 @@ export const useStreamLookup = () => {
 
   useEffect(() => {
     if (shouldSearchForStreams(queue)) {
-      const currentSong: QueueItem = queue.queueItems[queue.currentSong];
 
-      if (currentSong && queueActions.trackHasNoFirstStream(currentSong)) {
-        dispatch(queueActions.findStreamsForTrack(queue.currentSong));
-        return;
-      }
+      const nextTrackToSearch = (queue.queueItems as QueueItem[]).findIndex(
+        (item, index) =>
+          index >= queue.currentSong &&
+                queueActions.trackHasNoFirstStream(item) &&
+                !item.error);
     
-      const nextTrackWithNoStream = (queue.queueItems as QueueItem[]).findIndex((item) => isEmpty(item.streams));
-    
-      if (nextTrackWithNoStream !== -1) {
-        dispatch(queueActions.findStreamsForTrack(nextTrackWithNoStream));
+      if (nextTrackToSearch !== -1) {
+        dispatch(queueActions.findStreamsForTrack(nextTrackToSearch));
       }
     }
   }, [queue]);


### PR DESCRIPTION
<!-- 
Please review contribution guidelines to ensure your PR is compliant: https://nukeop.gitbook.io/nuclear/contributing/contribution-guidelines

Make sure your changes are covered by tests. Test coverage needs to increase or stay the same for the PR to be merged, unless it's a change that doesn't change functionality (e.g. CSS changes, converting to Typescript, etc.).
 -->
Fixes the issue described in this [issue comment](https://github.com/nukeop/nuclear/issues/1710#issuecomment-2377616070). It lead to the queue looping over finding streams for a specific track and being stuck there. 
Should the item in error be removed from the queue or leaving it there is ok :thinking:?