### PR TITLE
New UI for displaying album with multiple discs on Spotify search result

### DIFF
--- a/packages/core/src/plugins/meta/spotify.test.ts
+++ b/packages/core/src/plugins/meta/spotify.test.ts
@@ -355,6 +355,7 @@ describe('SpotifyMetaProvider', () => {
           name: 'test track',
           artists: [{ name: 'test artist' }],
           duration_ms: 1000,
+          disc_number: 0,
           type: 'track'
         }]
       },

--- a/packages/core/src/plugins/meta/spotify.test.ts
+++ b/packages/core/src/plugins/meta/spotify.test.ts
@@ -380,6 +380,7 @@ describe('SpotifyMetaProvider', () => {
         title: 'test track',
         artist: 'test artist',
         duration: 1,
+        discNumber: 0,
         thumbnail: 'thumbnail.jpg'
       }]
     });

--- a/packages/core/src/plugins/meta/spotify.ts
+++ b/packages/core/src/plugins/meta/spotify.ts
@@ -169,6 +169,7 @@ export class SpotifyMetaProvider extends MetaProvider {
         title: track.name,
         artist: result.artists[0].name,
         duration: track.duration_ms/1000,
+        discNumber: track.disc_number,
         position: track.track_number,
         thumbnail: thumb
       }))

--- a/packages/core/src/plugins/meta/spotify.ts
+++ b/packages/core/src/plugins/meta/spotify.ts
@@ -1,3 +1,4 @@
+import spotify from '../../helpers/playlist/spotify';
 import { SpotifyArtist, SpotifyClientProvider, SpotifyImage, SpotifySimplifiedAlbum, SpotifyTrack, getImageSet } from '../../rest/Spotify';
 import Track from '../../structs/Track';
 import MetaProvider from '../metaProvider';
@@ -13,7 +14,7 @@ export class SpotifyMetaProvider extends MetaProvider {
     this.image = null;
     this.isDefault = true;
   }
-      
+
   async searchForArtists(query: string, limit=10): Promise<SearchResultsArtist[]> {
     const client = await SpotifyClientProvider.get();
     const results = await client.searchArtists(query, limit);
@@ -67,6 +68,7 @@ export class SpotifyMetaProvider extends MetaProvider {
       id: spotifyTrack.id,
       title: spotifyTrack.name,
       artist: spotifyTrack.artists[0].name,
+      discNumber: spotifyTrack.disc_number,
       source: SearchResultsSource.Spotify,
       thumb
     };
@@ -182,6 +184,6 @@ export class SpotifyMetaProvider extends MetaProvider {
 
     return this.fetchAlbumDetails(result.id, albumType);
   }
-  
+
 }
 

--- a/packages/core/src/plugins/plugins.types.ts
+++ b/packages/core/src/plugins/plugins.types.ts
@@ -62,6 +62,7 @@ export type SearchResultsTrack = {
     artist: string;
     source: SearchResultsSource;
     thumb?: string;
+    discNumber?: number | string;
 }
 
 export type ArtistTopTrack = {

--- a/packages/core/src/rest/Spotify.ts
+++ b/packages/core/src/rest/Spotify.ts
@@ -65,6 +65,7 @@ export type SpotifyTrack = {
   popularity: number;
   track_number: number;
   duration_ms: number;
+  disc_number: number;
   type: 'track';
 }
 

--- a/packages/core/src/structs/Track.ts
+++ b/packages/core/src/structs/Track.ts
@@ -15,9 +15,9 @@ export default class Track {
   title: string;
   name?: string;
   duration: string | number;
-  discNumber?: number;
-  
+
   position?: string | number;
+  discNumber?: string | number;
   playcount?: string | number;
   thumbnail?: string;
   extraArtists?: string[];
@@ -44,6 +44,7 @@ export default class Track {
     this.artist = data.artist;
     this.title = data.title;
     this.name = data.title;
+    this.discNumber = data.discNumber;
   }
 
   static fromSearchResultData(data: SearchResultsTrack): Track {

--- a/packages/core/src/structs/Track.ts
+++ b/packages/core/src/structs/Track.ts
@@ -15,6 +15,7 @@ export default class Track {
   title: string;
   name?: string;
   duration: string | number;
+  discNumber?: number;
   
   position?: string | number;
   playcount?: string | number;
@@ -35,6 +36,7 @@ export default class Track {
     this.duration = data.duration;
     this.position = data.position;
     this.thumbnail = data.thumbnail;
+    this.discNumber = data.discNumber;
   }
 
   addSearchResultData(data: SearchResultsTrack): void {

--- a/packages/ui/lib/components/GridTrackTable/index.tsx
+++ b/packages/ui/lib/components/GridTrackTable/index.tsx
@@ -3,18 +3,18 @@ import React, { useMemo, useState } from 'react';
 import { DragDropContext, DragDropContextProps, Droppable } from 'react-beautiful-dnd';
 import { FixedSizeList } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
- 
+
 import { TrackTableColumn, TrackTableExtraProps, TrackTableHeaders, TrackTableSettings, TrackTableStrings } from '../TrackTable/types';
 import { TextHeader } from './Headers/TextHeader';
 import { TextCell } from './Cells/TextCell';
 import { Track } from '../../types';
 import { getTrackThumbnail } from '../TrackRow';
- 
+
 import styles from './styles.scss';
 import artPlaceholder from '../../../resources/media/art_placeholder.png';
 import { ThumbnailCell } from './Cells/ThumbnailCell';
 import { GridTrackTableRow } from './GridTrackTableRow';
-import { isNumber, isString } from 'lodash';
+import { groupBy, isNumber, isString } from 'lodash';
 import { SelectionCell } from './Cells/SelectionCell';
 import { SelectionHeader } from './Headers/SelectionHeader';
 import { formatDuration } from '../../utils';
@@ -25,7 +25,7 @@ import { FavoriteCell } from './Cells/FavoriteCell';
 import { TitleCell } from './Cells/TitleCell';
 import { Input } from 'semantic-ui-react';
 import Button from '../Button';
- 
+
 export type GridTrackTableProps<T extends Track> = {
   className?: string;
   tracks: T[];
@@ -36,28 +36,28 @@ export type GridTrackTableProps<T extends Track> = {
 } & TrackTableHeaders
   & TrackTableSettings
   & TrackTableExtraProps<T>;
- 
+
 type ColumnWithWidth<T extends Track> = Column<T> & { columnWidth: string; };
 type TrackTableColumnInstance<T extends Track> = ColumnInstance<T> & UseSortByColumnProps<T>;
 type TrackTableHeaderGroup<T extends Track> = HeaderGroup<T> & UseSortByColumnProps<T>;
 type TrackTableInstance<T extends Track> = TableInstance<T> & UseGlobalFiltersInstanceProps<T> & UseSortByInstanceProps<T> & UseRowSelectInstanceProps<T>;
 type TrackTableState<T extends Track> = TableState<T> & UseSortByState<T>;
 export type TrackTableRow<T extends Track> = Row<T> & UseRowSelectRowProps<T>;
- 
+
 export const GridTrackTable = <T extends Track>({
   className,
   tracks,
   customColumns=[],
   isTrackFavorite,
   onDragEnd,
- 
+
   positionHeader,
   thumbnailHeader,
   artistHeader,
   titleHeader,
   albumHeader,
   durationHeader,
- 
+
   displayHeaders=true,
   displayDeleteButton=true,
   displayPosition=true,
@@ -69,217 +69,235 @@ export const GridTrackTable = <T extends Track>({
   displayCustom=true,
   selectable=true,
   searchable=false,
- 
+
   ...extraProps
 }: GridTrackTableProps<T>) => {
   const shouldDisplayDuration = displayDuration && tracks.every(track => Boolean(track.duration));
-  const columns = useMemo(() => [
-    selectable && {
-      id: TrackTableColumn.Selection,
-      Header: SelectionHeader,
-      Cell: SelectionCell,
-      columnWidth: '7.5em'
-    },
-    displayPosition && {
-      id: TrackTableColumn.Position,
-      Header: ({ column }) => <TextHeader
-        data-testid='position-header'
-        column={column as TrackTableColumnInstance<Track>}
-        header={positionHeader}
-        isCentered
-      />,
-      accessor: (track: T) => `${track.discNumber || 1}.${track.position}`,
-      Cell: PositionCell,
-      enableSorting: true,
-      columnWidth: '4em'
-    } as Column<T>,
-    displayThumbnail && {
-      id: TrackTableColumn.Thumbnail,
-      Header: ({ column }) => <TextHeader column={column} header={thumbnailHeader} />,
-      accessor: (track: T) => getTrackThumbnail(track) || artPlaceholder,
-      Cell: ThumbnailCell,
-      columnWidth: '3em'
-    },
-    displayFavorite && {
-      id: TrackTableColumn.Favorite,
-      accessor: isTrackFavorite,
-      Cell: FavoriteCell,
-      columnWidth: '3em'
-    },
-    {
-      id: TrackTableColumn.Title,
-      Header: ({ column }) => <TextHeader column={column} header={titleHeader} />,
-      accessor: (track: T) => track.title ?? track.name,
-      Cell: TitleCell,
-      enableSorting: true,
-      columnWidth: 'minmax(8em, 1fr)'
-    },
-    displayArtist && {
-      id: TrackTableColumn.Artist,
-      Header: ({ column }) => <TextHeader column={column} header={artistHeader} />,
-      accessor: (track: T) => isString(track.artist)
-        ? track.artist
-        : track.artist.name,
-      Cell: TextCell,
-      enableSorting: true,
-      columnWidth: '6em'
-    },
-    displayAlbum && {
-      id: TrackTableColumn.Album,
-      Header: ({ column }: { column: TrackTableColumnInstance<T> }) => <TextHeader column={column} header={albumHeader} />,
-      accessor: (track: T) => track.album,
-      enableSorting: true,
-      Cell: TextCell,
-      columnWidth: '6em'
-    } as Column<T>,
-    shouldDisplayDuration && {
-      id: TrackTableColumn.Duration,
-      Header: ({ column }) => <TextHeader column={column} header={durationHeader} />,
-      accessor: (track: T) => {
-        if (isString(track.duration)) {
-          return track.duration;
-        } else if (isNumber(track.duration)) {
-          return formatDuration(track.duration);
-        } else {
-          return null;
-        }
-      },
-      Cell: TextCell,
-      columnWidth: '6em'
-    },
-    ...customColumns,
-    displayDeleteButton && {
-      id: TrackTableColumn.Delete,
-      Cell: DeleteCell,
-      columnWidth: '3em'
-    } as Column<T>
-  ].filter(Boolean), [displayDeleteButton, displayPosition, displayThumbnail, displayFavorite, isTrackFavorite, titleHeader, displayArtist, artistHeader, displayAlbum, albumHeader, shouldDisplayDuration, durationHeader, selectable, positionHeader, thumbnailHeader]);
- 
-  const data = useMemo(() => tracks, [tracks]);
- 
-  const initialState: Partial<TableState<T> & UseSortByState<T>> = {
-    sortBy: [{ id: TrackTableColumn.Position, desc: false }]
-  };
-  const table = useTable<T>({ columns, data, initialState }, useGlobalFilter, useSortBy, useRowSelect);
+  const groupedDisc = useMemo(() => groupBy(tracks, (track) => track.discNumber || 1), [tracks]);
+
   const [globalFilter, setGlobalFilterState] = useState(''); // Required, because useGlobalFilter does not provide a way to get the current filter value
- 
-  const {
-    getTableProps,
-    getTableBodyProps,
-    headerGroups,
-    rows,
-    prepareRow,
-    setGlobalFilter,
-    state: tableState,
-    selectedFlatRows
-  } = table as TrackTableInstance<T>;
- 
-  const onFilterClick = () => {
-    setGlobalFilter('');
-    setGlobalFilterState('');
-  };
- 
-  const gridTemplateColumns = columns.map((column: ColumnWithWidth<T>) => column.columnWidth ?? '1fr').join(' ');
- 
-  // Disabled when there are selected rows, or when sorted by anything other than position
-  const isDragDisabled = !onDragEnd || selectedFlatRows.length > 0 || (tableState as TrackTableState<T>).sortBy[0]?.id !== TrackTableColumn.Position;
- 
-  return <div className={styles.track_table_wrapper}>
-    {
-      searchable &&
-      <div className={styles.track_table_filter_row}>
-        <Input
-          data-testid='track-table-filter-input'
-          type='text'
-          placeholder={extraProps.strings.filterInputPlaceholder}
-          className={styles.track_table_filter_input}
-          onChange={(e) => {
-            setGlobalFilter(e.target.value);
-            setGlobalFilterState(e.target.value);
-          }}
-          value={globalFilter}
-        />
-        <Button
-          className={styles.track_table_filter_button}
-          onClick={onFilterClick}
-          borderless
-          color={'blue'}
-          icon='filter'
-        />
-      </div>
-    }
-    <div
-      className={styles.grid_track_table}
-      {...getTableProps()}
-    >
-      <div className={styles.track_table_head}>
-        {headerGroups.map(headerGroup => (
-          <div
-            key={headerGroup.id}
-            className={styles.track_table_header_row}
-            style={{ gridTemplateColumns: gridTemplateColumns + ' auto' }}
-            {...headerGroup.getHeaderGroupProps()}
-          >
-            {
-              headerGroup.headers.map((column: TrackTableHeaderGroup<T>) => (
-                <div
-                  key={column.id}
-                  className={styles.track_table_header_cell}
-                  {...column.getHeaderProps((column).getSortByToggleProps())}
-                >
-                  {column.render('Header', extraProps)}
-                </div>))
-            }
-          </div>
-        ))}
-      </div>
-      <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable
-          droppableId='track_table'
-          mode='virtual'
-          renderClone={GridTrackTableRowClone({
-            rows,
-            gridTemplateColumns,
-            extraProps
-          })}
-        >
-          {(droppableProvided, droppableSnapshot) => (
-            <div
-              data-testid='track-table-body'
-              className={styles.track_table_body}
-              ref={droppableProvided.innerRef}
-              {...getTableBodyProps()}
-              {...droppableProvided.droppableProps}
-            >
-              <AutoSizer
-                className={styles.track_table_auto_sizer}
-              >
-                {({ height, width }) =>
-                  <FixedSizeList
-                    className={styles.track_table_virtualized_list}
-                    height={height}
-                    width={width}
-                    itemSize={42}
-                    itemCount={rows.length}
-                    overscanCount={2}
-                    itemData={{
-                      rows: rows as Row<Track>[],
-                      prepareRow: prepareRow as (row: Row<Track>) => void,
-                      gridTemplateColumns,
-                      isDragDisabled,
-                      extraProps
-                    }}
-                    outerRef={droppableProvided.innerRef}
+
+  return (
+    <div className={styles.track_table_wrapper}>
+      {Object.entries(groupedDisc).map(([discNumber, discTracks]) => {
+        const data = useMemo(() => discTracks, [discTracks]);
+        const initialState: Partial<TableState<T> & UseSortByState<T>> = {
+          sortBy: [{ id: TrackTableColumn.Position, desc: false }]
+        };
+        const columns = useMemo(() => [
+          selectable && {
+            id: TrackTableColumn.Selection,
+            Header: SelectionHeader,
+            Cell: SelectionCell,
+            columnWidth: '7.5em'
+          },
+          displayPosition && {
+            id: TrackTableColumn.Position,
+            Header: ({ column }) => <TextHeader
+              data-testid='position-header'
+              column={column as TrackTableColumnInstance<Track>}
+              header={positionHeader}
+              isCentered
+            />,
+            accessor: (track: T) => track.position,
+            Cell: PositionCell,
+            enableSorting: true,
+            columnWidth: '4em'
+          } as Column<T>,
+          displayThumbnail && {
+            id: TrackTableColumn.Thumbnail,
+            Header: ({ column }) => <TextHeader column={column} header={thumbnailHeader} />,
+            accessor: (track: T) => getTrackThumbnail(track) || artPlaceholder,
+            Cell: ThumbnailCell,
+            columnWidth: '3em'
+          },
+          displayFavorite && {
+            id: TrackTableColumn.Favorite,
+            accessor: isTrackFavorite,
+            Cell: FavoriteCell,
+            columnWidth: '3em'
+          },
+          {
+            id: TrackTableColumn.Title,
+            Header: ({ column }) => <TextHeader column={column} header={titleHeader} />,
+            accessor: (track: T) => track.title ?? track.name,
+            Cell: TitleCell,
+            enableSorting: true,
+            columnWidth: 'minmax(8em, 1fr)'
+          },
+          displayArtist && {
+            id: TrackTableColumn.Artist,
+            Header: ({ column }) => <TextHeader column={column} header={artistHeader} />,
+            accessor: (track: T) => isString(track.artist)
+              ? track.artist
+              : track.artist.name,
+            Cell: TextCell,
+            enableSorting: true,
+            columnWidth: '6em'
+          },
+          displayAlbum && {
+            id: TrackTableColumn.Album,
+            Header: ({ column }: { column: TrackTableColumnInstance<T> }) => <TextHeader column={column} header={albumHeader} />,
+            accessor: (track: T) => track.album,
+            enableSorting: true,
+            Cell: TextCell,
+            columnWidth: '6em'
+          } as Column<T>,
+          shouldDisplayDuration && {
+            id: TrackTableColumn.Duration,
+            Header: ({ column }) => <TextHeader column={column} header={durationHeader} />,
+            accessor: (track: T) => {
+              if (isString(track.duration)) {
+                return track.duration;
+              } else if (isNumber(track.duration)) {
+                return formatDuration(track.duration);
+              } else {
+                return null;
+              }
+            },
+            Cell: TextCell,
+            columnWidth: '6em'
+          },
+          ...customColumns,
+          displayDeleteButton && {
+            id: TrackTableColumn.Delete,
+            Cell: DeleteCell,
+            columnWidth: '3em'
+          } as Column<T>
+        ].filter(Boolean), [displayDeleteButton, displayPosition, displayThumbnail, displayFavorite, isTrackFavorite, titleHeader, displayArtist, artistHeader, displayAlbum, albumHeader, shouldDisplayDuration, durationHeader, selectable, positionHeader, thumbnailHeader]);
+
+        const table = useTable<T>(
+          { columns, data, initialState },
+          useGlobalFilter,
+          useSortBy,
+          useRowSelect
+        );
+
+        const {
+          getTableProps,
+          getTableBodyProps,
+          headerGroups,
+          rows,
+          prepareRow,
+          setGlobalFilter,
+          state: tableState,
+          selectedFlatRows
+        } = table as TrackTableInstance<T>;
+
+        const onFilterClick = () => {
+          setGlobalFilter('');
+          setGlobalFilterState('');
+        };
+
+        const gridTemplateColumns = columns.map((column: ColumnWithWidth<T>) => column.columnWidth ?? '1fr').join(' ');
+
+        // Disabled when there are selected rows, or when sorted by anything other than position
+        const isDragDisabled = !onDragEnd || selectedFlatRows.length > 0 || (tableState as TrackTableState<T>).sortBy[0]?.id !== TrackTableColumn.Position;
+        return (
+          <div key={discNumber} className={styles.track_table_wrapper}>
+            {searchable && (
+              <div className={styles.track_table_filter_row}>
+                <Input
+                  data-testid='track-table-filter-input'
+                  type='text'
+                  placeholder={extraProps.strings.filterInputPlaceholder}
+                  className={styles.track_table_filter_input}
+                  onChange={(e) => {
+                    setGlobalFilter(e.target.value);
+                    setGlobalFilterState(e.target.value);
+                  }}
+                  value={globalFilter}
+                />
+                <Button
+                  className={styles.track_table_filter_button}
+                  onClick={onFilterClick}
+                  borderless
+                  color={'blue'}
+                  icon='filter'
+                />
+              </div>
+            )}
+            <div className={styles.grid_track_table} {...getTableProps()}>
+              {Object.keys(groupedDisc).length !== 1 && (
+                <h3>Disc {discNumber}</h3>
+              )}
+              <div className={styles.track_table_head}>
+                {headerGroups.map((headerGroup) => (
+                  <div
+                    key={headerGroup.id}
+                    className={styles.track_table_header_row}
+                    style={{ gridTemplateColumns: gridTemplateColumns + ' auto' }}
+                    {...headerGroup.getHeaderGroupProps()}
                   >
-                    {GridTrackTableRow}
-                  </FixedSizeList>
-                }
-              </AutoSizer>
+                    {headerGroup.headers.map(
+                      (column: TrackTableHeaderGroup<T>) => (
+                        <div
+                          key={column.id}
+                          className={styles.track_table_header_cell}
+                          {...column.getHeaderProps(
+                            column.getSortByToggleProps()
+                          )}
+                        >
+                          {column.render('Header', extraProps)}
+                        </div>
+                      )
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              <DragDropContext onDragEnd={onDragEnd}>
+                <Droppable
+                  droppableId={`track_table_disc_${discNumber}`}
+                  mode='virtual'
+                  renderClone={GridTrackTableRowClone({
+                    rows,
+                    gridTemplateColumns,
+                    extraProps
+                  })}
+                >
+                  {(droppableProvided) => (
+                    <div
+                      data-testid={`track-table-body-${discNumber}`}
+                      className={styles.track_table_body}
+                      ref={droppableProvided.innerRef}
+                      {...getTableBodyProps()}
+                      {...droppableProvided.droppableProps}
+                    >
+                      <AutoSizer
+                        className={styles.track_table_auto_sizer}
+                      >
+                        {({ height, width }) =>
+                          <FixedSizeList
+                            className={styles.track_table_virtualized_list}
+                            height={height}
+                            width={width}
+                            itemSize={42}
+                            itemCount={rows.length}
+                            overscanCount={2}
+                            itemData={{
+                              rows: rows as Row<Track>[],
+                              prepareRow: prepareRow as (row: Row<Track>) => void,
+                              gridTemplateColumns,
+                              isDragDisabled,
+                              extraProps
+                            }}
+                            outerRef={droppableProvided.innerRef}
+                          >
+                            {GridTrackTableRow}
+                          </FixedSizeList>
+                        }
+                      </AutoSizer>
+                    </div>
+                  )}
+                </Droppable>
+              </DragDropContext>
             </div>
-          )}
-        </Droppable>
-      </DragDropContext>
+          </div>
+        );
+      }
+      )}
     </div>
-  </div>;
+  );
 };
- 
+

--- a/packages/ui/lib/components/GridTrackTable/index.tsx
+++ b/packages/ui/lib/components/GridTrackTable/index.tsx
@@ -88,7 +88,7 @@ export const GridTrackTable = <T extends Track>({
         header={positionHeader}
         isCentered
       />,
-      accessor: (track: T) => track.position,
+      accessor: (track: T) => `${track.discNumber || 1}.${track.position}`,
       Cell: PositionCell,
       enableSorting: true,
       columnWidth: '4em'

--- a/packages/ui/lib/components/GridTrackTable/index.tsx
+++ b/packages/ui/lib/components/GridTrackTable/index.tsx
@@ -77,227 +77,165 @@ export const GridTrackTable = <T extends Track>({
 
   const [globalFilter, setGlobalFilterState] = useState(''); // Required, because useGlobalFilter does not provide a way to get the current filter value
 
-  return (
-    <div className={styles.track_table_wrapper}>
-      {Object.entries(groupedDisc).map(([discNumber, discTracks]) => {
-        const data = useMemo(() => discTracks, [discTracks]);
-        const initialState: Partial<TableState<T> & UseSortByState<T>> = {
-          sortBy: [{ id: TrackTableColumn.Position, desc: false }]
-        };
-        const columns = useMemo(() => [
-          selectable && {
-            id: TrackTableColumn.Selection,
-            Header: SelectionHeader,
-            Cell: SelectionCell,
-            columnWidth: '7.5em'
-          },
-          displayPosition && {
-            id: TrackTableColumn.Position,
-            Header: ({ column }) => <TextHeader
-              data-testid='position-header'
-              column={column as TrackTableColumnInstance<Track>}
-              header={positionHeader}
-              isCentered
-            />,
-            accessor: (track: T) => track.position,
-            Cell: PositionCell,
-            enableSorting: true,
-            columnWidth: '4em'
-          } as Column<T>,
-          displayThumbnail && {
-            id: TrackTableColumn.Thumbnail,
-            Header: ({ column }) => <TextHeader column={column} header={thumbnailHeader} />,
-            accessor: (track: T) => getTrackThumbnail(track) || artPlaceholder,
-            Cell: ThumbnailCell,
-            columnWidth: '3em'
-          },
-          displayFavorite && {
-            id: TrackTableColumn.Favorite,
-            accessor: isTrackFavorite,
-            Cell: FavoriteCell,
-            columnWidth: '3em'
-          },
-          {
-            id: TrackTableColumn.Title,
-            Header: ({ column }) => <TextHeader column={column} header={titleHeader} />,
-            accessor: (track: T) => track.title ?? track.name,
-            Cell: TitleCell,
-            enableSorting: true,
-            columnWidth: 'minmax(8em, 1fr)'
-          },
-          displayArtist && {
-            id: TrackTableColumn.Artist,
-            Header: ({ column }) => <TextHeader column={column} header={artistHeader} />,
-            accessor: (track: T) => isString(track.artist)
-              ? track.artist
-              : track.artist.name,
-            Cell: TextCell,
-            enableSorting: true,
-            columnWidth: '6em'
-          },
-          displayAlbum && {
-            id: TrackTableColumn.Album,
-            Header: ({ column }: { column: TrackTableColumnInstance<T> }) => <TextHeader column={column} header={albumHeader} />,
-            accessor: (track: T) => track.album,
-            enableSorting: true,
-            Cell: TextCell,
-            columnWidth: '6em'
-          } as Column<T>,
-          shouldDisplayDuration && {
-            id: TrackTableColumn.Duration,
-            Header: ({ column }) => <TextHeader column={column} header={durationHeader} />,
-            accessor: (track: T) => {
-              if (isString(track.duration)) {
-                return track.duration;
-              } else if (isNumber(track.duration)) {
-                return formatDuration(track.duration);
-              } else {
-                return null;
-              }
-            },
-            Cell: TextCell,
-            columnWidth: '6em'
-          },
-          ...customColumns,
-          displayDeleteButton && {
-            id: TrackTableColumn.Delete,
-            Cell: DeleteCell,
-            columnWidth: '3em'
-          } as Column<T>
-        ].filter(Boolean), [displayDeleteButton, displayPosition, displayThumbnail, displayFavorite, isTrackFavorite, titleHeader, displayArtist, artistHeader, displayAlbum, albumHeader, shouldDisplayDuration, durationHeader, selectable, positionHeader, thumbnailHeader]);
-
-        const table = useTable<T>(
-          { columns, data, initialState },
-          useGlobalFilter,
-          useSortBy,
-          useRowSelect
-        );
-
-        const {
-          getTableProps,
-          getTableBodyProps,
-          headerGroups,
-          rows,
-          prepareRow,
-          setGlobalFilter,
-          state: tableState,
-          selectedFlatRows
-        } = table as TrackTableInstance<T>;
-
-        const onFilterClick = () => {
-          setGlobalFilter('');
-          setGlobalFilterState('');
-        };
-
-        const gridTemplateColumns = columns.map((column: ColumnWithWidth<T>) => column.columnWidth ?? '1fr').join(' ');
-
-        // Disabled when there are selected rows, or when sorted by anything other than position
-        const isDragDisabled = !onDragEnd || selectedFlatRows.length > 0 || (tableState as TrackTableState<T>).sortBy[0]?.id !== TrackTableColumn.Position;
-        return (
-          <div key={discNumber} className={styles.track_table_wrapper}>
-            {searchable && (
-              <div className={styles.track_table_filter_row}>
-                <Input
-                  data-testid='track-table-filter-input'
-                  type='text'
-                  placeholder={extraProps.strings.filterInputPlaceholder}
-                  className={styles.track_table_filter_input}
-                  onChange={(e) => {
-                    setGlobalFilter(e.target.value);
-                    setGlobalFilterState(e.target.value);
-                  }}
-                  value={globalFilter}
-                />
-                <Button
-                  className={styles.track_table_filter_button}
-                  onClick={onFilterClick}
-                  borderless
-                  color={'blue'}
-                  icon='filter'
-                />
-              </div>
-            )}
-            <div className={styles.grid_track_table} {...getTableProps()}>
-              {Object.keys(groupedDisc).length !== 1 && (
-                <h3>Disc {discNumber}</h3>
-              )}
-              <div className={styles.track_table_head}>
-                {headerGroups.map((headerGroup) => (
-                  <div
-                    key={headerGroup.id}
-                    className={styles.track_table_header_row}
-                    style={{ gridTemplateColumns: gridTemplateColumns + ' auto' }}
-                    {...headerGroup.getHeaderGroupProps()}
-                  >
-                    {headerGroup.headers.map(
-                      (column: TrackTableHeaderGroup<T>) => (
-                        <div
-                          key={column.id}
-                          className={styles.track_table_header_cell}
-                          {...column.getHeaderProps(
-                            column.getSortByToggleProps()
-                          )}
-                        >
-                          {column.render('Header', extraProps)}
-                        </div>
-                      )
-                    )}
+  const generateColumns = () => [
+    selectable && {
+      id: TrackTableColumn.Selection,
+      Header: SelectionHeader,
+      Cell: SelectionCell,
+      columnWidth: '7.5em'
+    },
+    displayPosition && {
+      id: TrackTableColumn.Position,
+      Header: ({ column }) => <TextHeader data-testid='position-header' column={column} header={positionHeader} isCentered />,
+      accessor: (track: T) => track.position,
+      Cell: PositionCell,
+      enableSorting: true,
+      columnWidth: '4em'
+    },
+    displayThumbnail && {
+      id: TrackTableColumn.Thumbnail,
+      Header: ({ column }) => <TextHeader column={column} header={thumbnailHeader} />,
+      accessor: (track: T) => getTrackThumbnail(track) || artPlaceholder,
+      Cell: ThumbnailCell,
+      columnWidth: '3em'
+    },
+    displayFavorite && {
+      id: TrackTableColumn.Favorite,
+      accessor: isTrackFavorite,
+      Cell: FavoriteCell,
+      columnWidth: '3em'
+    },
+    {
+      id: TrackTableColumn.Title,
+      Header: ({ column }) => <TextHeader column={column} header={titleHeader} />,
+      accessor: (track: T) => track.title ?? track.name,
+      Cell: TitleCell,
+      enableSorting: true,
+      columnWidth: 'minmax(8em, 1fr)'
+    },
+    displayArtist && {
+      id: TrackTableColumn.Artist,
+      Header: ({ column }) => <TextHeader column={column} header={artistHeader} />,
+      accessor: (track: T) => isString(track.artist) ? track.artist : track.artist.name,
+      Cell: TextCell,
+      enableSorting: true,
+      columnWidth: '6em'
+    },
+    displayAlbum && {
+      id: TrackTableColumn.Album,
+      Header: ({ column }) => <TextHeader column={column} header={albumHeader} />,
+      accessor: (track: T) => track.album,
+      enableSorting: true,
+      Cell: TextCell,
+      columnWidth: '6em'
+    },
+    shouldDisplayDuration && {
+      id: TrackTableColumn.Duration,
+      Header: ({ column }) => <TextHeader column={column} header={durationHeader} />,
+      accessor: (track: T) => isString(track.duration) ? track.duration : formatDuration(track.duration),
+      Cell: TextCell,
+      columnWidth: '6em'
+    },
+    ...customColumns,
+    displayDeleteButton && {
+      id: TrackTableColumn.Delete,
+      Cell: DeleteCell,
+      columnWidth: '3em'
+    }
+  ].filter(Boolean);
+  
+  const renderTable = (data: T[], discNumber?: string) => {
+    const columns = useMemo(generateColumns, [displayDeleteButton, displayPosition, displayThumbnail, displayFavorite, isTrackFavorite, titleHeader, displayArtist, artistHeader, displayAlbum, albumHeader, shouldDisplayDuration, durationHeader, selectable, positionHeader, thumbnailHeader]);
+  
+    const table = useTable<T>(
+      { columns, data, initialState: { sortBy: [{ id: TrackTableColumn.Position, desc: false }] } },
+      useGlobalFilter, useSortBy, useRowSelect
+    );
+    
+    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow, setGlobalFilter, state: tableState, selectedFlatRows } = table as TrackTableInstance<T>;
+    const onFilterClick = () => setGlobalFilter('');
+    const gridTemplateColumns = columns.map((col: ColumnWithWidth<T>) => col.columnWidth ?? '1fr').join(' ');
+  
+    const isDragDisabled = !onDragEnd || selectedFlatRows.length > 0 || (tableState as TrackTableState<T>).sortBy[0]?.id !== TrackTableColumn.Position;
+  
+    return (
+      <div className={styles.track_table_wrapper}>
+        {searchable && (
+          <div className={styles.track_table_filter_row}>
+            <Input
+              data-testid='track-table-filter-input'
+              type='text'
+              placeholder={extraProps.strings.filterInputPlaceholder}
+              className={styles.track_table_filter_input}
+              onChange={(e) => setGlobalFilter(e.target.value)}
+              value={globalFilter}
+            />
+            <Button
+              className={styles.track_table_filter_button}
+              onClick={onFilterClick}
+              borderless
+              color={'blue'}
+              icon='filter'
+            />
+          </div>
+        )}
+        <div className={styles.grid_track_table} {...getTableProps()}>
+          {discNumber && <h3>Disc {discNumber}</h3>}
+          <div className={styles.track_table_head}>
+            {headerGroups.map((headerGroup) => (
+              <div key={headerGroup.id} className={styles.track_table_header_row} style={{ gridTemplateColumns: gridTemplateColumns + ' auto' }} {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column) => (
+                  <div key={column.id} className={styles.track_table_header_cell} {...column.getHeaderProps(column.getSortByToggleProps())}>
+                    {column.render('Header', extraProps)}
                   </div>
                 ))}
               </div>
-
-              <DragDropContext onDragEnd={onDragEnd}>
-                <Droppable
-                  droppableId={`track_table_disc_${discNumber}`}
-                  mode='virtual'
-                  renderClone={GridTrackTableRowClone({
-                    rows,
-                    gridTemplateColumns,
-                    extraProps
-                  })}
-                >
-                  {(droppableProvided) => (
-                    <div
-                      data-testid={`track-table-body-${discNumber}`}
-                      className={styles.track_table_body}
-                      ref={droppableProvided.innerRef}
-                      {...getTableBodyProps()}
-                      {...droppableProvided.droppableProps}
-                    >
-                      <AutoSizer
-                        className={styles.track_table_auto_sizer}
-                      >
-                        {({ height, width }) =>
-                          <FixedSizeList
-                            className={styles.track_table_virtualized_list}
-                            height={height}
-                            width={width}
-                            itemSize={42}
-                            itemCount={rows.length}
-                            overscanCount={2}
-                            itemData={{
-                              rows: rows as Row<Track>[],
-                              prepareRow: prepareRow as (row: Row<Track>) => void,
-                              gridTemplateColumns,
-                              isDragDisabled,
-                              extraProps
-                            }}
-                            outerRef={droppableProvided.innerRef}
-                          >
-                            {GridTrackTableRow}
-                          </FixedSizeList>
-                        }
-                      </AutoSizer>
-                    </div>
-                  )}
-                </Droppable>
-              </DragDropContext>
-            </div>
+            ))}
           </div>
-        );
-      }
-      )}
-    </div>
-  );
+          <DragDropContext onDragEnd={onDragEnd}>
+            <Droppable droppableId={'track_table'} mode='virtual' renderClone={GridTrackTableRowClone({ rows, gridTemplateColumns, extraProps })}>
+              {(droppableProvided) => (
+                <div data-testid={'track-table-body'} className={styles.track_table_body} ref={droppableProvided.innerRef} {...getTableBodyProps()} {...droppableProvided.droppableProps}>
+                  <AutoSizer className={styles.track_table_auto_sizer}>
+                    {({ height, width }) => (
+                      <FixedSizeList
+                        className={styles.track_table_virtualized_list}
+                        height={height}
+                        width={width}
+                        itemSize={42}
+                        itemCount={rows.length}
+                        overscanCount={2}
+                        itemData={{
+                          rows: rows as Row<Track>[],
+                          prepareRow: prepareRow as (row: Row<Track>) => void,
+                          gridTemplateColumns,
+                          isDragDisabled,
+                          extraProps
+                        }}
+                        outerRef={droppableProvided.innerRef}
+                      >
+                        {GridTrackTableRow}
+                      </FixedSizeList>
+                    )}
+                  </AutoSizer>
+                </div>
+              )}
+            </Droppable>
+          </DragDropContext>
+        </div>
+      </div>
+    );
+  };
+  
+  if (Object.keys(groupedDisc).length < 2) {
+    return renderTable(tracks);
+  } else {
+    return (
+      <div className={styles.track_table_wrapper}>
+        {Object.entries(groupedDisc).map(([discNumber, discTracks]) => renderTable(discTracks, discNumber))}
+      </div>
+    );
+  }
+  
 };
 

--- a/packages/ui/lib/types/index.ts
+++ b/packages/ui/lib/types/index.ts
@@ -12,6 +12,7 @@ export type Track = {
   album?: string;
   duration?: number | string;
   position?: number | string;
+  discNumber?: number;
   playcount?: number | string;
   thumbnail?: string;
   image?: { '#text'?: string }[];

--- a/packages/ui/lib/types/index.ts
+++ b/packages/ui/lib/types/index.ts
@@ -1,9 +1,9 @@
 export type Track = {
   uuid?: string;
   loading?: boolean;
-  error?: boolean | { 
-    message: string; 
-    details: string 
+  error?: boolean | {
+    message: string;
+    details: string
   };
   local?: boolean;
   artist: { name: string } | string;
@@ -12,7 +12,7 @@ export type Track = {
   album?: string;
   duration?: number | string;
   position?: number | string;
-  discNumber?: number;
+  discNumber?: number | string;
   playcount?: number | string;
   thumbnail?: string;
   image?: { '#text'?: string }[];

--- a/packages/ui/test/__snapshots__/gridTrackTable.test.tsx.snap
+++ b/packages/ui/test/__snapshots__/gridTrackTable.test.tsx.snap
@@ -736,3 +736,608 @@ exports[`(Snapshot) Grid track table - example data with all rows should render 
   </div>
 </DocumentFragment>
 `;
+
+exports[`(Snapshot) Grid track table - example data with multiple discs should render correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="track_table_wrapper"
+  >
+    <div
+      class="track_table_wrapper"
+    >
+      <div
+        class="grid_track_table"
+        role="table"
+      >
+        <h3>
+          Disc 0
+        </h3>
+        <div
+          class="track_table_head"
+        >
+          <div
+            class="track_table_header_row"
+            role="row"
+            style="grid-template-columns: 7.5em 4em 3em 3em minmax(8em, 1fr) 6em 6em 6em 3em auto;"
+          >
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+            >
+              <div
+                class="selection_header"
+              >
+                <div
+                  class="ui fitted checkbox nuclear checkbox"
+                  style="cursor: pointer;"
+                >
+                  <input
+                    class="hidden"
+                    readonly=""
+                    tabindex="0"
+                    title="Toggle All Rows Selected"
+                    type="checkbox"
+                    value=""
+                  />
+                  <label />
+                </div>
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header centered"
+                data-testid="position-header"
+              >
+                Position
+                <i
+                  aria-hidden="true"
+                  class="sort content ascending icon text_header_icon"
+                />
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header"
+              >
+                Thumbnail
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+            >
+               
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header"
+              >
+                Title
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header"
+              >
+                Artist
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header"
+              >
+                Album
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header"
+              >
+                Length
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+            >
+               
+            </div>
+          </div>
+        </div>
+        <div
+          class="track_table_body"
+          data-rbd-droppable-context-id="2"
+          data-rbd-droppable-id="track_table"
+          data-testid="track-table-body"
+          role="rowgroup"
+        >
+          <div
+            class="track_table_virtualized_list"
+            style="position: relative; height: 600px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+          >
+            <div
+              style="height: 42px; width: 100%;"
+            >
+              <div
+                class="grid_track_table_row"
+                data-rbd-draggable-context-id="2"
+                data-rbd-draggable-id="0"
+                data-testid="track-table-row"
+                role="row"
+                style="position: absolute; left: 0px; top: 0px; height: 42px; width: 100%; grid-template-columns: 7.5em 4em 3em 3em minmax(8em, 1fr) 6em 6em 6em 3em;"
+                tabindex="0"
+              >
+                <div
+                  class="selection_cell"
+                  role="cell"
+                >
+                  <div
+                    class="ui fitted checkbox nuclear checkbox"
+                    style="cursor: pointer;"
+                  >
+                    <input
+                      class="hidden"
+                      readonly=""
+                      tabindex="-1"
+                      title="Toggle Row Selected"
+                      type="checkbox"
+                      value=""
+                    />
+                    <label />
+                  </div>
+                </div>
+                <div
+                  class="grid_track_table_cell position_cell"
+                  data-testid="position-cell"
+                  role="cell"
+                >
+                  <button
+                    class="ui pink tiny circular icon button nuclear button play_button"
+                    data-testid="play-now"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="play icon"
+                    />
+                  </button>
+                  <span
+                    class="position_cell_value"
+                  >
+                    1
+                  </span>
+                </div>
+                <div
+                  class="grid_track_table_cell thumbnail_cell"
+                  role="cell"
+                />
+                <div
+                  class="grid_track_table_cell favorite_cell"
+                  data-testid="favorite-cell"
+                  role="cell"
+                >
+                  <button
+                    class="ui tiny basic circular icon button nuclear button borderless"
+                    data-testid="favorite-button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="heart outline icon"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="grid_track_table_cell text_cell title_cell"
+                  data-testid="title-cell"
+                  role="cell"
+                >
+                  <span
+                    class="title_cell_content"
+                  >
+                    <span
+                      class="title_cell_value"
+                    >
+                      Test Title
+                    </span>
+                    <span
+                      class="title_cell_buttons"
+                    >
+                      <button
+                        class="ui tiny basic circular icon button nuclear button borderless title_cell_button"
+                        data-testid="add-to-queue"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="plus icon"
+                        />
+                      </button>
+                      <button
+                        class="ui tiny basic circular icon button nuclear button borderless title_cell_button"
+                        data-testid="track-popup-trigger"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="ellipsis horizontal icon"
+                        />
+                      </button>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  class="grid_track_table_cell text_cell"
+                  role="cell"
+                >
+                  Test Artist
+                </div>
+                <div
+                  class="grid_track_table_cell text_cell"
+                  role="cell"
+                >
+                  Test Album
+                </div>
+                <div
+                  class="grid_track_table_cell text_cell"
+                  role="cell"
+                >
+                  1:00
+                </div>
+                <div
+                  class="delete_cell"
+                  data-testid="delete-cell"
+                  role="cell"
+                >
+                  <button
+                    class="ui tiny basic circular icon button nuclear button borderless"
+                    data-testid="delete-button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="times icon"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="track_table_wrapper"
+    >
+      <div
+        class="grid_track_table"
+        role="table"
+      >
+        <h3>
+          Disc 1
+        </h3>
+        <div
+          class="track_table_head"
+        >
+          <div
+            class="track_table_header_row"
+            role="row"
+            style="grid-template-columns: 7.5em 4em 3em 3em minmax(8em, 1fr) 6em 6em 6em 3em auto;"
+          >
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+            >
+              <div
+                class="selection_header"
+              >
+                <div
+                  class="ui fitted checkbox nuclear checkbox"
+                  style="cursor: pointer;"
+                >
+                  <input
+                    class="hidden"
+                    readonly=""
+                    tabindex="0"
+                    title="Toggle All Rows Selected"
+                    type="checkbox"
+                    value=""
+                  />
+                  <label />
+                </div>
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header centered"
+                data-testid="position-header"
+              >
+                Position
+                <i
+                  aria-hidden="true"
+                  class="sort content ascending icon text_header_icon"
+                />
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header"
+              >
+                Thumbnail
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+            >
+               
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header"
+              >
+                Title
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header"
+              >
+                Artist
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header"
+              >
+                Album
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+              style="cursor: pointer;"
+              title="Toggle SortBy"
+            >
+              <div
+                class="text_header"
+              >
+                Length
+              </div>
+            </div>
+            <div
+              class="track_table_header_cell"
+              colspan="1"
+              role="columnheader"
+            >
+               
+            </div>
+          </div>
+        </div>
+        <div
+          class="track_table_body"
+          data-rbd-droppable-context-id="3"
+          data-rbd-droppable-id="track_table"
+          data-testid="track-table-body"
+          role="rowgroup"
+        >
+          <div
+            class="track_table_virtualized_list"
+            style="position: relative; height: 600px; width: 600px; overflow: auto; will-change: transform; direction: ltr;"
+          >
+            <div
+              style="height: 42px; width: 100%;"
+            >
+              <div
+                class="grid_track_table_row"
+                data-rbd-draggable-context-id="3"
+                data-rbd-draggable-id="0"
+                data-testid="track-table-row"
+                role="row"
+                style="position: absolute; left: 0px; top: 0px; height: 42px; width: 100%; grid-template-columns: 7.5em 4em 3em 3em minmax(8em, 1fr) 6em 6em 6em 3em;"
+                tabindex="0"
+              >
+                <div
+                  class="selection_cell"
+                  role="cell"
+                >
+                  <div
+                    class="ui fitted checkbox nuclear checkbox"
+                    style="cursor: pointer;"
+                  >
+                    <input
+                      class="hidden"
+                      readonly=""
+                      tabindex="-1"
+                      title="Toggle Row Selected"
+                      type="checkbox"
+                      value=""
+                    />
+                    <label />
+                  </div>
+                </div>
+                <div
+                  class="grid_track_table_cell position_cell"
+                  data-testid="position-cell"
+                  role="cell"
+                >
+                  <button
+                    class="ui pink tiny circular icon button nuclear button play_button"
+                    data-testid="play-now"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="play icon"
+                    />
+                  </button>
+                  <span
+                    class="position_cell_value"
+                  >
+                    2
+                  </span>
+                </div>
+                <div
+                  class="grid_track_table_cell thumbnail_cell"
+                  role="cell"
+                />
+                <div
+                  class="grid_track_table_cell favorite_cell"
+                  data-testid="favorite-cell"
+                  role="cell"
+                >
+                  <button
+                    class="ui tiny basic circular icon button nuclear button borderless"
+                    data-testid="favorite-button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="heart outline icon"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="grid_track_table_cell text_cell title_cell"
+                  data-testid="title-cell"
+                  role="cell"
+                >
+                  <span
+                    class="title_cell_content"
+                  >
+                    <span
+                      class="title_cell_value"
+                    >
+                      Test Title 2
+                    </span>
+                    <span
+                      class="title_cell_buttons"
+                    >
+                      <button
+                        class="ui tiny basic circular icon button nuclear button borderless title_cell_button"
+                        data-testid="add-to-queue"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="plus icon"
+                        />
+                      </button>
+                      <button
+                        class="ui tiny basic circular icon button nuclear button borderless title_cell_button"
+                        data-testid="track-popup-trigger"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="ellipsis horizontal icon"
+                        />
+                      </button>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  class="grid_track_table_cell text_cell"
+                  role="cell"
+                >
+                  Test Artist 2
+                </div>
+                <div
+                  class="grid_track_table_cell text_cell"
+                  role="cell"
+                >
+                  Test Album
+                </div>
+                <div
+                  class="grid_track_table_cell text_cell"
+                  role="cell"
+                >
+                  1:00
+                </div>
+                <div
+                  class="delete_cell"
+                  data-testid="delete-cell"
+                  role="cell"
+                >
+                  <button
+                    class="ui tiny basic circular icon button nuclear button borderless"
+                    data-testid="delete-button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="times icon"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/ui/test/gridTrackTable.test.tsx
+++ b/packages/ui/test/gridTrackTable.test.tsx
@@ -52,3 +52,31 @@ makeSnapshotTest(GridTrackTable, {
   titleHeader: 'Title',
   durationHeader: 'Length'
 }, '(Snapshot) Grid track table - example data with all rows');
+
+makeSnapshotTest(GridTrackTable, {
+  tracks: [
+    {
+      position: 1, 
+      thumbnail: 'https://i.imgur.com/4euOws2.jpg', 
+      artist: 'Test Artist',
+      title: 'Test Title',
+      album: 'Test Album',
+      duration: '1:00',
+      discNumber: '0'
+    }, {
+      position: 2, 
+      thumbnail: 'https://i.imgur.com/4euOws2.jpg', 
+      artist: 'Test Artist 2',
+      name: 'Test Title 2',
+      album: 'Test Album',
+      duration: '1:00',
+      discNumber: '1'
+    } as Track
+  ],
+  positionHeader: 'Position',
+  thumbnailHeader: 'Thumbnail',
+  artistHeader: 'Artist',
+  albumHeader: 'Album',
+  titleHeader: 'Title',
+  durationHeader: 'Length'
+}, '(Snapshot) Grid track table - example data with multiple discs');


### PR DESCRIPTION
# Current Behavior
https://github.com/nukeop/nuclear/issues/1671
In the current UI, multi-CD albums are displayed in a single, continuous track list. Each track from every CD is shown sequentially without any indication of which CD it belongs to, creating potential confusion for the user. Tracks across different CDs are appended in a single list, resulting in duplicate track numbers (e.g. 1st track in both CD 1 and CD 2 are labeled with 1).
# New Behavior
Implement a distinct list for each CD within the album for spotify search result, effectively dividing the album view by CD and ensuring each CD starts from track number 1. UI remained unchanged for album search using other API.
![Album_with_multiple_discs](https://github.com/user-attachments/assets/09ad9dc1-9143-4665-99f3-3d878ad5b6f0)