### PR TITLE
Made buttons fully clickable in mini player

### DIFF
--- a/packages/ui/lib/components/MiniPlayer/MiniPlayOptions/index.tsx
+++ b/packages/ui/lib/components/MiniPlayer/MiniPlayOptions/index.tsx
@@ -20,6 +20,7 @@ const MiniPlayOptionControl: React.FC<PlayOptionControlProps> = ({
   enabled = true,
   onToggle
 }) => <button
+  className={styles.mini_play_options_control}
   onClick={onToggle}
 >
   <Icon
@@ -40,9 +41,8 @@ const MiniPlayOptions: React.FC<MiniPlayOptionsProps> = ({
   return <div className={styles.mini_play_options}>
     <NeumorphicBox small borderRadius='5px'>
       <button
+        className={styles.mini_play_options_button}
         onClick={onDisableMiniPlayer}
-        
-       
       >
         <Icon
           size='large'
@@ -52,6 +52,7 @@ const MiniPlayOptions: React.FC<MiniPlayOptionsProps> = ({
     </NeumorphicBox>
     <NeumorphicBox small borderRadius='5px'>
       <button
+        className={styles.mini_play_options_button}
         onClick={isExpanded ? contract : expand}
       >
         <Icon
@@ -60,9 +61,9 @@ const MiniPlayOptions: React.FC<MiniPlayOptionsProps> = ({
         />
       </button>
       {
-        isExpanded && playOptions.slice(1).map(playOption => <MiniPlayOptionControl 
+        isExpanded && playOptions.slice(1).map(playOption => <MiniPlayOptionControl
           key={playOption.name}
-          {...playOption} 
+          {...playOption}
         />)
       }
     </NeumorphicBox>

--- a/packages/ui/lib/components/MiniPlayer/MiniPlayOptions/styles.scss
+++ b/packages/ui/lib/components/MiniPlayer/MiniPlayOptions/styles.scss
@@ -8,28 +8,33 @@
   flex-flow: row;
   justify-content: space-between;
   width: 100%;
-  
-  button {
+
+  &_button, &_control {
     @include common.center;
     display: flex;
-    
+
     background: transparent;
     border: none;
     outline: none;
     cursor: pointer;
-    width: 2em;
-    height: 2em;
-    
-    padding: 0;
+
     margin: 0;
-    
-    &:not(:first-child) {
-      margin-top: 1em;
-    }
-    
+
     i {
       color: common.$white;
-     margin: 0;
-   }
- }
+      margin: 0;
+    }
+  }
+
+  &_button {
+    padding: 1.25em 1.12em;
+  }
+
+  &_control {
+    padding: 0.75em 1.12em;
+
+    &:last-child {
+      padding-bottom: 1em;
+    }
+  }
 }

--- a/packages/ui/lib/components/NeumorphicBox/index.tsx
+++ b/packages/ui/lib/components/NeumorphicBox/index.tsx
@@ -5,6 +5,7 @@ import styles from './styles.scss';
 
 export type NeumorphicBoxProps = {
   borderRadius?: string;
+  padding?: string;
   small?: boolean;
   pressed?: boolean;
   children?: React.ReactNode;
@@ -13,6 +14,7 @@ export type NeumorphicBoxProps = {
 const NeumorphicBox: React.FC<NeumorphicBoxProps> = ({
   children,
   borderRadius,
+  padding,
   small,
   pressed
 }) => <div
@@ -21,7 +23,7 @@ const NeumorphicBox: React.FC<NeumorphicBoxProps> = ({
     { [styles.small]: small },
     { [styles.pressed]: pressed }
   )}
-  style={{ borderRadius }}
+  style={{ borderRadius, padding }}
 >
   {children}
 </div>;

--- a/packages/ui/lib/components/NeumorphicBox/styles.scss
+++ b/packages/ui/lib/components/NeumorphicBox/styles.scss
@@ -11,25 +11,24 @@ $contrast: 5%;
   height: 100%;
   border-radius: 25px;
   background: transparent;
-  box-shadow: $bigDisplacement $bigDisplacement $bigBlur color.adjust(common.$background, $lightness: -$contrast), 
+  box-shadow: $bigDisplacement $bigDisplacement $bigBlur color.adjust(common.$background, $lightness: -$contrast),
   (-$bigDisplacement) (-$bigDisplacement) $bigBlur color.adjust(common.$background, $lightness: $contrast);
   color: common.$white;
-  padding: 1em;
   margin: 1em;
 
   &.small {
-    box-shadow: $smallDisplacement $smallDisplacement $smallBlur color.adjust(common.$background, $lightness: -$contrast), 
+    box-shadow: $smallDisplacement $smallDisplacement $smallBlur color.adjust(common.$background, $lightness: -$contrast),
     (-$smallDisplacement) (-$smallDisplacement) $smallBlur color.adjust(common.$background, $lightness: $contrast);
     z-index:1000;
   }
 
   &.pressed {
-    box-shadow: inset $bigDisplacement $bigDisplacement $bigBlur color.adjust(common.$background, $lightness: -$contrast), 
+    box-shadow: inset $bigDisplacement $bigDisplacement $bigBlur color.adjust(common.$background, $lightness: -$contrast),
     inset (-$bigDisplacement) (-$bigDisplacement) $bigBlur color.adjust(common.$background, $lightness: $contrast);
   }
 
   &.small.pressed {
-    box-shadow: inset $smallDisplacement $smallDisplacement $smallBlur color.adjust(common.$background, $lightness: -$contrast), 
+    box-shadow: inset $smallDisplacement $smallDisplacement $smallBlur color.adjust(common.$background, $lightness: -$contrast),
     inset (-$smallDisplacement) (-$smallDisplacement) $smallBlur color.adjust(common.$background, $lightness: $contrast);
   }
 }

--- a/packages/ui/lib/components/VolumeControls/PlaybackRateSlider/index.tsx
+++ b/packages/ui/lib/components/VolumeControls/PlaybackRateSlider/index.tsx
@@ -24,7 +24,7 @@ const PlaybackRateSlider: React.FC<PlaybackRateSliderProps> = ({
   updatePlaybackRate,
   isPlaybackRateOpen
 }) => {
-  
+
   const rateOptions = PLAYBACK_RATES.map((item, index) => <div key={index} onClick={() => updatePlaybackRate(index)}>{item}</div>);
 
   return (
@@ -33,9 +33,10 @@ const PlaybackRateSlider: React.FC<PlaybackRateSliderProps> = ({
     >
       <NeumorphicBox
         borderRadius='10px'
+        padding='1em'
       >
         <div className={styles.rates_box}>{rateOptions}</div>
-        <Range  
+        <Range
           value={playbackRate}
           height={4}
           width='100%'

--- a/packages/ui/test/__snapshots__/miniPlayer.test.tsx.snap
+++ b/packages/ui/test/__snapshots__/miniPlayer.test.tsx.snap
@@ -12,7 +12,9 @@ exports[`(Snapshot) Mini player should render correctly 1`] = `
         class="neumorphic_box small"
         style="border-radius: 5px;"
       >
-        <button>
+        <button
+          class="mini_play_options_button"
+        >
           <i
             aria-hidden="true"
             class="chevron left large icon"
@@ -23,7 +25,9 @@ exports[`(Snapshot) Mini player should render correctly 1`] = `
         class="neumorphic_box small"
         style="border-radius: 5px;"
       >
-        <button>
+        <button
+          class="mini_play_options_button"
+        >
           <i
             aria-hidden="true"
             class="ellipsis horizontal large icon"


### PR DESCRIPTION
Description:

I found uncomfortable to click exactly on icon, so I've changed layout a little bit to be able to click on whole button to invoke action.

Layout may change a little, but I've tried to keep original sizes of button.

For tests I created a new snapshot of mini player.

I hope, you'll find these changes helpful, please tell me if I need to change something before submission.