### PR TITLE
Middle Mouse button skips song

### DIFF
--- a/packages/app/app/containers/PlayerBarContainer/hooks.ts
+++ b/packages/app/app/containers/PlayerBarContainer/hooks.ts
@@ -94,7 +94,7 @@ export const usePlayerControlsProps = () => {
     [dispatch, seek, goBackThreshold]
   );
 
-    useEffect(() => { 
+    useEffect(() => {
     const handleMiddleClick = (event) => {
       if (event.button === 1) {
         event.preventDefault();


### PR DESCRIPTION
This is a feature where you press the middle mouse button and it skips the next song in the queue. Issue #1275
