### PR TITLE
fix: improve pill badge readability in dark mode

### DIFF
--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -64,37 +64,37 @@ const badgeVariants = cva(
       {
         variant: 'pill',
         color: 'green',
-        className: 'bg-accent-green text-foreground',
+        className: 'bg-accent-green text-black',
       },
       {
         variant: 'pill',
         color: 'cyan',
-        className: 'bg-accent-cyan text-foreground',
+        className: 'bg-accent-cyan text-black',
       },
       {
         variant: 'pill',
         color: 'orange',
-        className: 'bg-accent-orange text-foreground',
+        className: 'bg-accent-orange text-black',
       },
       {
         variant: 'pill',
         color: 'red',
-        className: 'bg-accent-red text-foreground',
+        className: 'bg-accent-red text-black',
       },
       {
         variant: 'pill',
         color: 'yellow',
-        className: 'bg-accent-yellow text-foreground',
+        className: 'bg-accent-yellow text-black',
       },
       {
         variant: 'pill',
         color: 'purple',
-        className: 'bg-accent-purple text-foreground',
+        className: 'bg-accent-purple text-black',
       },
       {
         variant: 'pill',
         color: 'blue',
-        className: 'bg-accent-blue text-foreground',
+        className: 'bg-accent-blue text-black',
       },
     ],
     defaultVariants: {


### PR DESCRIPTION
## Summary

- Pill badge variants use `text-foreground` for text color, which becomes near-white in dark mode (`oklch(0.9 0.008 5)`)
- Accent background colors do not have dark mode overrides — they remain light across all themes
- This causes **poor contrast (light text on light background)** in dark mode, making badge labels unreadable (visible in Preferences → Plugins → Store)
- Fix: replace `text-foreground` with `text-black` for all pill badge color variants, ensuring consistent readability regardless of theme

## Test plan

- [ ] Open Preferences → Plugins → Store in dark mode and verify category tags are readable
- [ ] Check all pill badge colors (green, cyan, orange, red, yellow, purple, blue) in both light and dark mode
- [ ] Verify light mode appearance is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)