### PR TITLE
feat: Add audio output device selector with Bluetooth hotplug support

### DIFF
--- a/packages/hifi/src/Sound.tsx
+++ b/packages/hifi/src/Sound.tsx
@@ -14,6 +14,7 @@ export const Sound: React.FC<SoundProps> = ({
   status,
   seek,
   volume,
+  sinkId,
   preload = 'auto',
   crossOrigin = '',
   onTimeUpdate,
@@ -31,6 +32,16 @@ export const Sound: React.FC<SoundProps> = ({
   useHlsSource(audioRef, src);
   useMseSource(audioRef, src, onError, onSourceInvalid);
   usePlaybackStatus(audioRef, status, src.url, onError);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || !sinkId || !('setSinkId' in audio)) {
+      return;
+    }
+    (audio as HTMLAudioElement & { setSinkId(id: string): Promise<void> })
+      .setSinkId(sinkId)
+      .catch(() => {});
+  }, [sinkId]);
 
   useEffect(() => {
     const audio = audioRef.current;

--- a/packages/hifi/src/index.ts
+++ b/packages/hifi/src/index.ts
@@ -6,7 +6,7 @@ export { Volume } from './plugins/Volume';
 export { Stereo } from './plugins/Stereo';
 export { BiQuadFilter } from './plugins/BiQuadFilter';
 export { Equalizer } from './plugins/Equalizer';
-export { type AudioSource, type SoundStatus } from './types';
+export { type AudioSource, type SoundStatus, type SoundProps } from './types';
 export { LoggerProvider } from './LoggerProvider';
 export { SoundError, type SoundErrorCode } from './SoundError';
 export { type HifiLogger } from './types';

--- a/packages/hifi/src/types.ts
+++ b/packages/hifi/src/types.ts
@@ -20,6 +20,7 @@ export type SoundProps = {
   status: SoundStatus;
   seek?: number;
   volume?: number;
+  sinkId?: string;
   preload?: HTMLAudioElement['preload'];
   crossOrigin?: ScriptHTMLAttributes<HTMLAudioElement>['crossOrigin'];
   onTimeUpdate?: (args: { position: number; duration: number }) => void;

--- a/packages/i18n/src/locales/en_US.json
+++ b/packages/i18n/src/locales/en_US.json
@@ -562,6 +562,12 @@
       "chore": "Chore",
       "plugin": "Plugin",
       "docs": "Docs"
+    },
+    "audioOutput": {
+      "title": "Audio Output",
+      "deviceLabel": "Device",
+      "deviceDescription": "Select the audio output device for playback",
+      "deviceDefault": "System default"
     }
   }
 }

--- a/packages/player/changelog.json
+++ b/packages/player/changelog.json
@@ -1,5 +1,17 @@
 [
   {
+    "date": "2026-07-30T00:00",
+    "description": "Add audio output device selector. You can now choose your playback device (speakers, Bluetooth headphones, etc.) from Settings -> Audio Output. Devices are detected automatically when connected or disconnected.",
+    "type": "feature",
+    "contributors": ["nukeop"],
+    "tags": [
+      {
+        "label": "Playback",
+        "color": "green"
+      }
+    ]
+  },
+  {
     "date": "2026-07-20T00:00",
     "description": "Fix bluetooth issues on Linux.",
     "type": "fix",

--- a/packages/player/src-tauri/src/main.rs
+++ b/packages/player/src-tauri/src/main.rs
@@ -69,14 +69,17 @@ fn apply_linux_workarounds() {
     // Request high-latency audio streams. Web Audio's low-latency request
     // forces the PipeWire quantum down below what Bluetooth A2DP can service,
     // killing playback: https://github.com/nukeop/nuclear/discussions/1980
+    //
+    // Higher values (200ms / 4096 samples) give Bluetooth codecs (AAC, LDAC,
+    // SBC) enough buffer to avoid underruns and dropouts.
     if std::env::var("PULSE_LATENCY_MSEC").is_err() {
         unsafe {
-            std::env::set_var("PULSE_LATENCY_MSEC", "60");
+            std::env::set_var("PULSE_LATENCY_MSEC", "200");
         }
     }
     if std::env::var("PIPEWIRE_LATENCY").is_err() {
         unsafe {
-            std::env::set_var("PIPEWIRE_LATENCY", "1024/48000");
+            std::env::set_var("PIPEWIRE_LATENCY", "4096/48000");
         }
     }
 }

--- a/packages/player/src/components/SoundProvider.tsx
+++ b/packages/player/src/components/SoundProvider.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from '@nuclearplayer/i18n';
 import { useCoreSetting } from '../hooks/useCoreSetting';
 import { eventBus } from '../services/eventBus';
 import { Logger } from '../services/logger';
+import { useAudioOutputStore } from '../stores/audioOutputStore';
 import { useQueueStore } from '../stores/queueStore';
 import { useSoundStore } from '../stores/soundStore';
 import { errorMessage } from '../utils/errorMessage';
@@ -28,6 +29,8 @@ export const SoundProvider: FC<PropsWithChildren> = ({ children }) => {
   const [volume01] = useCoreSetting<number>('playback.volume');
   const [muted] = useCoreSetting<boolean>('playback.muted');
   const volumePercent = muted ? 0 : Math.round((volume01 ?? 1) * 100);
+  const selectedSinkId = useAudioOutputStore((s) => s.selectedSinkId);
+  const isAudioOutputSupported = useAudioOutputStore((s) => s.isSupported);
 
   useEffect(() => {
     LoggerProvider.init(Logger.streaming);
@@ -107,6 +110,9 @@ export const SoundProvider: FC<PropsWithChildren> = ({ children }) => {
           status={status}
           seek={seek}
           volume={volumePercent}
+          sinkId={
+            isAudioOutputSupported ? (selectedSinkId ?? undefined) : undefined
+          }
           preload={preload}
           crossOrigin={crossOrigin}
           onTimeUpdate={handleTimeUpdate}

--- a/packages/player/src/initPlayerApp.tsx
+++ b/packages/player/src/initPlayerApp.tsx
@@ -20,6 +20,7 @@ import { initMpdHandler } from './services/mpd';
 import { initPlaybackEventBridge } from './services/playbackEventBridge';
 import { hydratePluginsFromRegistry } from './services/plugins/pluginBootstrap';
 import { ytdlpEnsureInstalled } from './services/tauri/commands';
+import { initializeAudioOutputStore } from './stores/audioOutputStore';
 import { initializeFavoritesStore } from './stores/favoritesStore';
 import { initializePlaylistStore } from './stores/playlistStore';
 import { initializeQueueStore } from './stores/queueStore';
@@ -38,6 +39,7 @@ export const initPlayerApp = async (
     .then(() => initializeQueueStore())
     .then(() => initializeFavoritesStore())
     .then(() => initializePlaylistStore())
+    .then(() => initializeAudioOutputStore())
     .then(() => registerBuiltInCoreSettings())
     .then(() => initDiscoveryService())
     .then(() => initMcpHandler())

--- a/packages/player/src/stores/audioOutputStore.ts
+++ b/packages/player/src/stores/audioOutputStore.ts
@@ -1,0 +1,92 @@
+import { LazyStore } from '@tauri-apps/plugin-store';
+import { create } from 'zustand';
+
+import { Logger } from '../services/logger';
+
+const AUDIO_OUTPUT_FILE = 'audio-output.json';
+const store = new LazyStore(AUDIO_OUTPUT_FILE);
+
+export type AudioDevice = {
+  deviceId: string;
+  groupId: string;
+  label: string;
+};
+
+type AudioOutputState = {
+  devices: AudioDevice[];
+  selectedSinkId: string | null;
+  isSupported: boolean;
+  isInitialized: boolean;
+
+  initialize: () => Promise<void>;
+  selectDevice: (deviceId: string) => Promise<void>;
+  refreshDevices: () => Promise<void>;
+};
+
+const enumerateAudioOutputs = async (): Promise<AudioDevice[]> => {
+  try {
+    const allDevices = await navigator.mediaDevices.enumerateDevices();
+    return allDevices
+      .filter((d) => d.kind === 'audiooutput')
+      .map((d) => ({
+        deviceId: d.deviceId,
+        groupId: d.groupId,
+        label: d.label || `Audio output ${d.deviceId.slice(0, 8)}...`,
+      }));
+  } catch {
+    return [];
+  }
+};
+
+export const useAudioOutputStore = create<AudioOutputState>((set, get) => ({
+  devices: [],
+  selectedSinkId: null,
+  isSupported: false,
+  isInitialized: false,
+
+  initialize: async () => {
+    const supportsSetSinkId =
+      'setSinkId' in HTMLAudioElement.prototype &&
+      typeof HTMLAudioElement.prototype.setSinkId === 'function';
+
+    set({ isSupported: supportsSetSinkId });
+
+    const persistedSinkId = await store.get<string>('selectedSinkId');
+    const initialDevices = await enumerateAudioOutputs();
+
+    set({
+      devices: initialDevices,
+      selectedSinkId: persistedSinkId || null,
+      isInitialized: true,
+    });
+
+    navigator.mediaDevices.addEventListener('devicechange', () => {
+      get().refreshDevices();
+    });
+  },
+
+  selectDevice: async (deviceId: string) => {
+    set({ selectedSinkId: deviceId });
+    await store.set('selectedSinkId', deviceId);
+    await store.save();
+    Logger.playback.debug(`Audio output device: ${deviceId}`);
+  },
+
+  refreshDevices: async () => {
+    const devices = await enumerateAudioOutputs();
+    const { selectedSinkId } = get();
+
+    const stillExists = devices.some((d) => d.deviceId === selectedSinkId);
+    set({ devices });
+
+    if (!stillExists && selectedSinkId) {
+      set({ selectedSinkId: null });
+      await store.set('selectedSinkId', '');
+      await store.save();
+    }
+  },
+}));
+
+export const initializeAudioOutputStore = async (): Promise<void> => {
+  await useAudioOutputStore.getState().initialize();
+};

--- a/packages/player/src/views/Settings/AudioOutputSection.tsx
+++ b/packages/player/src/views/Settings/AudioOutputSection.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from '@nuclearplayer/i18n';
+import { Select } from '@nuclearplayer/ui';
+
+import { useAudioOutputStore } from '../../stores/audioOutputStore';
+
+const DEFAULT_DEVICE_ID = 'default';
+
+export const AudioOutputSection = () => {
+  const { t } = useTranslation('preferences');
+  const devices = useAudioOutputStore((s) => s.devices);
+  const selectedSinkId = useAudioOutputStore((s) => s.selectedSinkId);
+  const selectDevice = useAudioOutputStore((s) => s.selectDevice);
+  const isSupported = useAudioOutputStore((s) => s.isSupported);
+
+  if (!isSupported) {
+    return null;
+  }
+
+  const options = [
+    { id: DEFAULT_DEVICE_ID, label: t('audioOutput.deviceDefault') },
+    ...devices.map((d) => ({ id: d.deviceId, label: d.label })),
+  ];
+
+  const isDefault = !selectedSinkId || selectedSinkId === DEFAULT_DEVICE_ID;
+  const currentValue = isDefault ? DEFAULT_DEVICE_ID : selectedSinkId;
+
+  return (
+    <section
+      data-testid="audio-output-section"
+      className="mb-6 flex w-full flex-col items-start justify-start"
+    >
+      <h2 className="mb-3 flex w-full flex-0 flex-row text-left text-2xl font-bold">
+        {t('audioOutput.title')}
+      </h2>
+      <div className="flex w-full flex-1 flex-col">
+        <Select
+          label={t('audioOutput.deviceLabel')}
+          description={t('audioOutput.deviceDescription')}
+          options={options}
+          value={currentValue}
+          onValueChange={(value) => {
+            if (value === DEFAULT_DEVICE_ID) {
+              selectDevice('');
+            } else {
+              selectDevice(value);
+            }
+          }}
+        />
+      </div>
+    </section>
+  );
+};

--- a/packages/player/src/views/Settings/Settings.tsx
+++ b/packages/player/src/views/Settings/Settings.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from '@nuclearplayer/i18n';
 import { ScrollableArea, ViewShell } from '@nuclearplayer/ui';
 
+import { AudioOutputSection } from './AudioOutputSection';
 import { SettingsSection } from './SettingsSection';
 import { useSettingsGroups } from './useSettingsGroups';
 
@@ -13,6 +14,7 @@ export const Settings = () => {
       <div className="flex w-full flex-col items-center justify-center overflow-hidden">
         <ScrollableArea className="max-w-120 flex-1 overflow-hidden">
           <div className="px-2">
+            <AudioOutputSection />
             {groups.map((group) => (
               <SettingsSection
                 key={group.name}


### PR DESCRIPTION
## Summary

Fixes audio not working through Bluetooth devices on Linux. Nuclear always played through the system default audio output, so when a Bluetooth device was connected, WebKitGTK kept routing to the wrong sink (or dropped audio entirely).

## Changes

### Audio output device selection
- **New `audioOutputStore`**: enumerates audio output devices via `navigator.mediaDevices.enumerateDevices()`, persists the selected device with `LazyStore`, and listens for `devicechange` events so Bluetooth devices appear/disappear in real time
- **`hifi/Sound`**: new `sinkId` prop that applies `HTMLAudioElement.setSinkId()` when a device is selected (gracefully ignored when unsupported)
- **`SoundProvider`**: wires the selected sink into the `<audio>` element
- **Settings UI**: new **Audio Output** section with a device dropdown (Settings -> Audio Output)

### Bluetooth A2DP stability (Linux)
- Increased `PULSE_LATENCY_MSEC` from 60ms to 200ms
- Increased `PIPEWIRE_LATENCY` from `1024/48000` to `4096/48000`

These larger buffers give Bluetooth codecs (SBC, AAC, LDAC) enough headroom to avoid underruns and dropouts.

## How to test

1. Connect a Bluetooth headset/speaker
2. Open Settings -> Audio Output
3. Select the Bluetooth device (or System default)
4. Play a track — audio should route to the selected device
5. Disconnect/reconnect the Bluetooth device — the list updates automatically